### PR TITLE
feat: m5cores3 sim for esp specific development

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,6 +4,12 @@ version = 4
 
 [[package]]
 name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "allocator-api2"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c583acf993cf4245c4acb0a2cc2ab1f9cc097de73411bb6d3647ff6af2b1013d"
@@ -19,6 +25,12 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "az"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
 
 [[package]]
 name = "base64"
@@ -77,10 +89,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "compact_str"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
 
 [[package]]
 name = "const-default"
@@ -234,6 +269,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -250,6 +294,12 @@ checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
 ]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "embassy-embedded-hal"
@@ -412,6 +462,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "embedded-graphics"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e8da660bb0c829b34a56a965490597f82a55e767b91f9543be80ce8ccb416fe"
+dependencies = [
+ "az",
+ "byteorder",
+ "embedded-graphics-core",
+ "float-cmp",
+ "micromath",
+]
+
+[[package]]
+name = "embedded-graphics-core"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95743bef3ff70fcba3930246c4e6872882bbea0dcc6da2ca860112e0cd4bd09f"
+dependencies = [
+ "az",
+ "byteorder",
+]
+
+[[package]]
+name = "embedded-graphics-unicodefonts"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a82ef1580d1bff3e89bd3e68069acb24910b66001aaab1738ce9de8d03d2ab1e"
+dependencies = [
+ "embedded-graphics",
+]
+
+[[package]]
 name = "embedded-hal"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -433,6 +515,16 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4c685bbef7fe13c3c6dd4da26841ed3980ef33e841cddfa15ce8a8fb3f1884"
 dependencies = [
+ "embedded-hal 1.0.0",
+]
+
+[[package]]
+name = "embedded-hal-bus"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513e0b3a8fb7d3013a8ae17a834283f170deaf7d0eeab0a7c1a36ad4dd356d22"
+dependencies = [
+ "critical-section",
  "embedded-hal 1.0.0",
 ]
 
@@ -514,7 +606,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "641e43d6a60244429117ef2fa7a47182120c7561336ea01f6fb08d634f46bae1"
 dependencies = [
- "allocator-api2",
+ "allocator-api2 0.3.1",
  "cfg-if",
  "document-features",
  "enumset",
@@ -696,7 +788,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "162ec711c8d06e79c67b75d01595539e86b0aac209643af98ca87a12250428b3"
 dependencies = [
- "allocator-api2",
+ "allocator-api2 0.3.1",
  "cfg-if",
  "document-features",
  "embassy-executor",
@@ -813,10 +905,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "fugit"
@@ -945,6 +1052,11 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2 0.2.21",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "heapless"
@@ -1026,6 +1138,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1066,6 +1187,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "kasuari"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fe90c1150662e858c7d5f945089b7517b0a80d8bf7ba4b1b5ffc984e7230a5b"
+dependencies = [
+ "hashbrown",
+ "thiserror",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1076,6 +1207,15 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "line-clipping"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f4de44e98ddbf09375cbf4d17714d18f39195f4f4894e8524501726fd9a8a4a"
+dependencies = [
+ "bitflags 2.11.0",
+]
 
 [[package]]
 name = "linked_list_allocator"
@@ -1105,6 +1245,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+dependencies = [
+ "hashbrown",
+]
+
+[[package]]
 name = "m57aim-motor"
 version = "0.1.0"
 dependencies = [
@@ -1125,6 +1274,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "micromath"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3c8dda44ff03a2f238717214da50f65d5a53b45cd213a7370424ffdb6fae815"
+
+[[package]]
+name = "mipidsi"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790ebd28bd67addbccf41b1c0c188c26bb9f5bdcd91d4d6da9bd558e20d97a1d"
+dependencies = [
+ "embedded-graphics-core",
+ "embedded-hal 1.0.0",
+ "heapless 0.8.0",
+]
+
+[[package]]
+name = "mousefood"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490c1ffdb94062231282102b75a38d47022faf28549c5f282aa5253354b62ff2"
+dependencies = [
+ "embedded-graphics",
+ "embedded-graphics-unicodefonts",
+ "ratatui-core",
+ "thiserror",
+]
+
+[[package]]
 name = "nb"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1138,6 +1316,12 @@ name = "nb"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d5439c4ad607c3c23abf66de8c8bf57ba8adcd1f129e699851a6e43935d339d"
+
+[[package]]
+name = "num-conv"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
 name = "num-traits"
@@ -1273,6 +1457,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "proc-macro-crate"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1316,6 +1506,56 @@ name = "rand_core"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+
+[[package]]
+name = "ratatui"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1ce67fb8ba4446454d1c8dbaeda0557ff5e94d39d5e5ed7f10a65eb4c8266bc"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
+dependencies = [
+ "bitflags 2.11.0",
+ "compact_str",
+ "hashbrown",
+ "indoc",
+ "itertools",
+ "kasuari",
+ "lru",
+ "strum",
+ "thiserror",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.2",
+]
+
+[[package]]
+name = "ratatui-widgets"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
+dependencies = [
+ "bitflags 2.11.0",
+ "hashbrown",
+ "indoc",
+ "instability",
+ "itertools",
+ "line-clipping",
+ "ratatui-core",
+ "strum",
+ "time",
+ "unicode-segmentation",
+ "unicode-width 0.2.2",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -1487,6 +1727,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "sim-m5cores3"
+version = "0.1.0"
+dependencies = [
+ "critical-section",
+ "embassy-executor",
+ "embassy-futures",
+ "embassy-sync 0.7.2",
+ "embassy-time",
+ "esp-alloc",
+ "esp-backtrace",
+ "esp-bootloader-esp-idf",
+ "esp-hal",
+ "esp-println",
+ "esp-rtos",
+ "log",
+ "ossm",
+ "pattern-engine",
+ "sim-m5cores3-board",
+ "sim-motor",
+ "static_cell",
+]
+
+[[package]]
+name = "sim-m5cores3-board"
+version = "0.1.0"
+dependencies = [
+ "embassy-time",
+ "embedded-graphics",
+ "embedded-hal 1.0.0",
+ "embedded-hal-bus",
+ "esp-hal",
+ "libm",
+ "log",
+ "mipidsi",
+ "mousefood",
+ "ratatui",
+ "static_cell",
+]
+
+[[package]]
 name = "sim-motor"
 version = "0.1.0"
 dependencies = [
@@ -1540,6 +1820,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "static_cell"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1585,7 +1871,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
- "unicode-width",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -1640,6 +1926,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
 name = "toml_datetime"
 version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1688,10 +1992,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-truncate"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
+dependencies = [
+ "itertools",
+ "unicode-segmentation",
+ "unicode-width 0.2.2",
+]
+
+[[package]]
 name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unsafe-libyaml"

--- a/boards/sim-m5cores3/Cargo.toml
+++ b/boards/sim-m5cores3/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "sim-m5cores3-board"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+esp-hal = { version = "1.0", features = ["unstable", "esp32s3"] }
+embedded-hal = "1.0"
+embedded-hal-bus = "0.3.0"
+embedded-graphics = "0.8"
+ratatui = { version = "0.30", default-features = false }
+mipidsi = "0.10.0"
+embassy-time = "0.5.0"
+libm = "0.2"
+log = "0.4"
+static_cell = "2.1.1"
+mousefood = { version = "0.4.0", default-features = false, features = [
+    "fonts",
+] }

--- a/boards/sim-m5cores3/src/display.rs
+++ b/boards/sim-m5cores3/src/display.rs
@@ -1,0 +1,54 @@
+/// ILI9342C Display initialization for M5Stack CoreS3.
+///
+/// Sets up SPI and initializes the display via the mipidsi driver.
+/// The display reset is handled externally by the AW9523B I/O expander
+/// before this module is called.
+use embedded_hal_bus::spi::ExclusiveDevice;
+use esp_hal::delay::Delay;
+use esp_hal::gpio::Output;
+use esp_hal::spi::master::Spi;
+use esp_hal::Blocking;
+use log::info;
+use mipidsi::interface::SpiInterface;
+use mipidsi::models::ILI9342CRgb565;
+use mipidsi::options::{ColorInversion, ColorOrder};
+use mipidsi::Builder;
+use static_cell::StaticCell;
+
+type SpiDev = ExclusiveDevice<Spi<'static, Blocking>, Output<'static>, Delay>;
+
+pub type Display = mipidsi::Display<
+    SpiInterface<'static, SpiDev, Output<'static>>,
+    ILI9342CRgb565,
+    mipidsi::NoResetPin,
+>;
+
+
+static SPI_BUFFER: StaticCell<[u8; 4_096]> = StaticCell::new();
+
+/// Initialize the ILI9342C display over SPI.
+///
+/// Assumes the LCD has already been reset via the AW9523B I/O expander.
+///
+/// Panics if called more than once (StaticCell enforces single initialization).
+pub fn init(
+    spi: Spi<'static, Blocking>,
+    cs: Output<'static>,
+    dc: Output<'static>,
+) -> Display {
+    let spi_device = ExclusiveDevice::new(spi, cs, Delay::new()).expect("SPI device creation");
+
+    let buffer = SPI_BUFFER.init([0u8; 4_096]);
+    let di = SpiInterface::new(spi_device, dc, buffer);
+
+    let mut delay = Delay::new();
+
+    let display = Builder::new(ILI9342CRgb565, di)
+        .color_order(ColorOrder::Bgr)
+        .invert_colors(ColorInversion::Inverted)
+        .init(&mut delay)
+        .expect("Failed to initialize ILI9342C display");
+
+    info!("ILI9342C display initialized (320x240)");
+    display
+}

--- a/boards/sim-m5cores3/src/io_expander.rs
+++ b/boards/sim-m5cores3/src/io_expander.rs
@@ -1,0 +1,43 @@
+/// AW9523B I/O Expander initialization for M5Stack CoreS3.
+///
+/// Configures pin 9 (port 1, bit 1) as output and performs a reset pulse
+/// for the ILI9342C LCD controller.
+/// Uses raw I2C register writes to avoid dependency on external crates.
+use embedded_hal::delay::DelayNs;
+use embedded_hal::i2c::I2c;
+use log::info;
+
+const AW9523B_ADDR: u8 = 0x58;
+
+// Register addresses
+const REG_OUTPUT_PORT1: u8 = 0x03;
+const REG_CONFIG_PORT1: u8 = 0x05;
+const REG_CTL: u8 = 0x11; // Global control: push-pull mode
+
+// Pin assignments on the AW9523B
+const LCD_RESET_BIT: u8 = 1 << 1; // Port 1, pin 1 = physical pin 9
+
+/// Initialize the AW9523B and perform the LCD reset sequence.
+///
+/// The LCD reset pin is on port 1, bit 1 (pin 9 of the AW9523B).
+/// Reset sequence: drive low → wait 10ms → drive high → wait 50ms.
+pub fn init<I: I2c, D: DelayNs>(i2c: &mut I, delay: &mut D) {
+    // Set push-pull mode for port 1 (register 0x11, bit 4 = 0 for push-pull)
+    let mut buf = [0u8; 1];
+    let _ = i2c.write_read(AW9523B_ADDR, &[REG_CTL], &mut buf);
+    let _ = i2c.write(AW9523B_ADDR, &[REG_CTL, buf[0] & !0x10]);
+
+    // Configure port 1 pin 1 as output (0 = output in config register)
+    let _ = i2c.write_read(AW9523B_ADDR, &[REG_CONFIG_PORT1], &mut buf);
+    let _ = i2c.write(AW9523B_ADDR, &[REG_CONFIG_PORT1, buf[0] & !LCD_RESET_BIT]);
+
+    // LCD reset sequence: pull low → delay → pull high → delay
+    let _ = i2c.write_read(AW9523B_ADDR, &[REG_OUTPUT_PORT1], &mut buf);
+    let _ = i2c.write(AW9523B_ADDR, &[REG_OUTPUT_PORT1, buf[0] & !LCD_RESET_BIT]);
+    delay.delay_ms(10);
+    let _ = i2c.write_read(AW9523B_ADDR, &[REG_OUTPUT_PORT1], &mut buf);
+    let _ = i2c.write(AW9523B_ADDR, &[REG_OUTPUT_PORT1, buf[0] | LCD_RESET_BIT]);
+    delay.delay_ms(50);
+
+    info!("AW9523B: LCD reset complete");
+}

--- a/boards/sim-m5cores3/src/lib.rs
+++ b/boards/sim-m5cores3/src/lib.rs
@@ -1,0 +1,10 @@
+#![no_std]
+extern crate alloc;
+
+pub mod display;
+pub mod io_expander;
+pub mod pmu;
+pub mod renderer;
+
+pub use display::Display;
+pub use renderer::{FrameState, create_terminal, render_ui};

--- a/boards/sim-m5cores3/src/pmu.rs
+++ b/boards/sim-m5cores3/src/pmu.rs
@@ -1,0 +1,27 @@
+/// AXP2101 Power Management Unit initialization for M5Stack CoreS3.
+///
+/// Configures the DLDO1 rail to power the LCD backlight.
+/// Uses raw I2C register writes to avoid dependency on external crates
+/// that may not yet support embedded-hal 1.0.
+use embedded_hal::i2c::I2c;
+use log::info;
+
+const AXP2101_ADDR: u8 = 0x34;
+
+// Register addresses
+const REG_DLDO1_VOLTAGE: u8 = 0x99;
+const REG_DLDO_ENABLE: u8 = 0x90;
+
+/// Initialize the AXP2101 PMU, enabling DLDO1 at ~3.3V for the LCD backlight.
+pub fn init<I: I2c>(i2c: &mut I) {
+    // Set DLDO1 voltage to 3.3V (0x1C = 3300mV in 100mV steps from 500mV)
+    // Voltage = 500 + (value * 100) mV, so 0x1C (28) = 500 + 2800 = 3300mV
+    let _ = i2c.write(AXP2101_ADDR, &[REG_DLDO1_VOLTAGE, 0x1C]);
+
+    // Enable DLDO1: read current enable register, set bit 7
+    let mut buf = [0u8; 1];
+    let _ = i2c.write_read(AXP2101_ADDR, &[REG_DLDO_ENABLE], &mut buf);
+    let _ = i2c.write(AXP2101_ADDR, &[REG_DLDO_ENABLE, buf[0] | 0x80]);
+
+    info!("AXP2101: DLDO1 enabled at 3.3V (LCD backlight)");
+}

--- a/boards/sim-m5cores3/src/renderer.rs
+++ b/boards/sim-m5cores3/src/renderer.rs
@@ -1,0 +1,224 @@
+/// Ratatui-powered renderer for the CoreS3 display via mousefood.
+/// 
+extern crate alloc;
+
+use alloc::boxed::Box;
+use alloc::string::String as AllocString;
+use core::fmt::Write;
+use embedded_graphics::pixelcolor::{Rgb565, Rgb888, RgbColor};
+use mousefood::fonts;
+use mousefood::{ColorTheme, EmbeddedBackend, EmbeddedBackendConfig, TerminalAlignment};
+use ratatui::Terminal;
+use ratatui::layout::{Alignment, Constraint, Layout, Rect};
+use ratatui::widgets::{Block, Borders, Paragraph};
+
+use crate::display::Display;
+
+const CARRIAGE: &str = "[████]";
+
+#[derive(Clone)]
+pub struct FrameState {
+    pub position: f64,
+    pub depth: f64,
+    pub stroke: f64,
+    pub velocity: f64,
+    pub sensation: f64,
+    pub fps: u32,
+    pub state: &'static str,
+}
+
+
+pub type OssmTerminal<'a> = Terminal<EmbeddedBackend<'a, Display, Rgb565>>;
+
+pub fn create_terminal(display: &mut Display) -> OssmTerminal<'_> {
+    let config = EmbeddedBackendConfig {
+        font_regular: fonts::MONO_6X13,
+        font_bold: Some(fonts::MONO_6X13_BOLD),
+        font_italic: Some(fonts::MONO_6X13_ITALIC),
+        flush_callback: Box::new(|_| {}),
+        vertical_alignment: TerminalAlignment::Start,
+        horizontal_alignment: TerminalAlignment::Start,
+        color_theme: ColorTheme {
+            foreground: Rgb888::GREEN,
+            ..ColorTheme::ansi()
+        },
+    };
+    let backend = EmbeddedBackend::new(display, config);
+    let mut terminal = Terminal::new(backend).expect("terminal init");
+    let _ = terminal.clear();
+    terminal
+}
+
+pub fn render_ui(frame: &mut ratatui::Frame, state: &FrameState) {
+    let area = frame.area();
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title_alignment(Alignment::Center)
+        .title(" OSSM Simulator ")
+        .padding(ratatui::widgets::Padding::uniform(1));
+
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    // Vertical layout: FPS top, rail centred, details bottom
+    let rows = Layout::vertical([
+        Constraint::Length(1), // 0: FPS
+        Constraint::Fill(1),   // 1: flex space
+        Constraint::Length(1), // 2: rail
+        Constraint::Fill(1),   // 3: flex space
+        Constraint::Length(1), // 4: pattern
+        Constraint::Length(1), // 5: state
+        Constraint::Length(1), // 6: depth
+        Constraint::Length(1), // 7: stroke
+        Constraint::Length(1), // 8: speed
+        Constraint::Length(1), // 9: sensation
+    ])
+    .split(inner);
+
+    // FPS counter
+    let mut fps_str = AllocString::with_capacity(8);
+    let _ = write!(fps_str, "{} fps", state.fps);
+    frame.render_widget(Paragraph::new(fps_str).alignment(Alignment::Right), rows[0]);
+
+    // OSSM Sim
+    frame.render_widget(
+        Paragraph::new(build_rail(state.position, inner.width as usize)),
+        rows[2],
+    );
+
+    // Details
+    frame.render_widget(Paragraph::new("Pattern: Deeper"), rows[4]);
+
+    let mut state_line = AllocString::with_capacity(16);
+    state_line.push_str("State:  ");
+    state_line.push_str(state.state);
+    frame.render_widget(Paragraph::new(state_line), rows[5]);
+    render_gauge(frame, rows[6], "Depth:  ", state.depth, 0.0, 1.0);
+    render_gauge(frame, rows[7], "Stroke: ", state.stroke, 0.0, 1.0);
+    render_gauge(frame, rows[8], "Speed:  ", state.velocity, 0.0, 1.0);
+    render_gauge(frame, rows[9], "Sense:  ", state.sensation, -1.0, 1.0);
+}
+
+fn build_rail(position_frac: f64, width: usize) -> AllocString {
+    let carriage_len = CARRIAGE.chars().count();
+    let track_len = width.saturating_sub(carriage_len);
+    let pos = libm::round(position_frac * track_len as f64) as usize;
+    let pos = pos.min(track_len);
+
+    let mut s = AllocString::with_capacity(width);
+    for _ in 0..pos {
+        s.push('=');
+    }
+    s.push_str(CARRIAGE);
+    for _ in (pos + carriage_len)..width {
+        s.push('=');
+    }
+    s
+}
+
+fn render_gauge(frame: &mut ratatui::Frame, area: Rect, label: &str, value: f64, min: f64, max: f64) {
+    let bipolar = min < 0.0 && max > 0.0;
+
+    let cols = Layout::horizontal([
+        Constraint::Length(8), // label
+        Constraint::Fill(1),   // bar
+        Constraint::Length(5), // value (e.g. "-1.00")
+    ])
+    .split(area);
+
+    frame.render_widget(Paragraph::new(label), cols[0]);
+
+    let bar_width = cols[1].width as usize;
+    if bipolar {
+        frame.render_widget(Paragraph::new(build_bipolar_bar(value, bar_width)), cols[1]);
+    } else {
+        let normalised = if max > min { (value - min) / (max - min) } else { 0.0 };
+        frame.render_widget(Paragraph::new(build_bar(normalised, bar_width)), cols[1]);
+    }
+
+    let mut v = AllocString::with_capacity(7);
+    if bipolar {
+        let _ = write!(v, "{:>5.2}", value);
+    } else {
+        let _ = write!(v, "{:.2}", value);
+    }
+    frame.render_widget(Paragraph::new(v).alignment(Alignment::Right), cols[2]);
+}
+
+fn build_bar(value: f64, width: usize) -> AllocString {
+    let inner = width.saturating_sub(2);
+    let filled = libm::round(value * inner as f64) as usize;
+    let filled = filled.min(inner);
+
+    let mut s = AllocString::with_capacity(width);
+    s.push('[');
+    for _ in 0..filled.saturating_sub(1) {
+        s.push('=');
+    }
+    if filled > 0 {
+        s.push('>');
+    }
+    for _ in filled..inner {
+        s.push(' ');
+    }
+    s.push(']');
+    s
+}
+
+fn build_bipolar_bar(value: f64, width: usize) -> AllocString {
+    let inner = width.saturating_sub(2);
+    let mid = inner / 2;
+    let clamped = value.clamp(-1.0, 1.0);
+    // How many cells the bar extends from centre
+    let extent = libm::round(libm::fabs(clamped) * mid as f64) as usize;
+    let extent = extent.min(mid);
+
+    let mut s = AllocString::with_capacity(width);
+    s.push('[');
+    if clamped < 0.0 && extent > 0 {
+        // Negative: arrow grows leftward from centre  [ <====|     ]
+        let start = mid - extent;
+        for i in 0..inner {
+            if i < start {
+                s.push(' ');
+            } else if i == start {
+                s.push('<');
+            } else if i < mid {
+                s.push('=');
+            } else if i == mid {
+                s.push('|');
+            } else {
+                s.push(' ');
+            }
+        }
+    } else if clamped > 0.0 && extent > 0 {
+        // Positive: arrow grows rightward from centre [     |====> ]
+        let end = mid + extent;
+        for i in 0..inner {
+            if i < mid {
+                s.push(' ');
+            } else if i == mid {
+                s.push('|');
+            } else if i < end {
+                s.push('=');
+            } else if i == end {
+                s.push('>');
+            } else {
+                s.push(' ');
+            }
+        }
+    } else {
+        // Zero: just the centre marker [     |     ]
+        for i in 0..inner {
+            if i == mid {
+                s.push('|');
+            } else {
+                s.push(' ');
+            }
+        }
+    }
+    s.push(']');
+    s
+}
+

--- a/firmware/sim-m5cores3/.cargo/config.toml
+++ b/firmware/sim-m5cores3/.cargo/config.toml
@@ -1,0 +1,12 @@
+[build]
+target = "xtensa-esp32s3-none-elf"
+rustflags = ["-C", "link-arg=-nostartfiles"]
+
+[target.xtensa-esp32s3-none-elf]
+runner = "espflash flash --monitor"
+
+[env]
+ESP_LOG = "info"
+
+[unstable]
+build-std = ["alloc", "core"]

--- a/firmware/sim-m5cores3/Cargo.toml
+++ b/firmware/sim-m5cores3/Cargo.toml
@@ -1,0 +1,51 @@
+[package]
+name = "sim-m5cores3"
+version = "0.1.0"
+edition = "2024"
+rust-version = "1.88"
+
+[dependencies]
+ossm = { path = "../../ossm" }
+pattern-engine = { path = "../../features/pattern-engine" }
+sim-motor = { path = "../../drivers/sim-motor" }
+sim-m5cores3-board = { path = "../../boards/sim-m5cores3" }
+
+esp-hal = { version = "~1.0", features = ["log-04", "esp32s3", "unstable"] }
+
+esp-rtos = { version = "0.2.0", features = [
+    "log-04",
+    "embassy",
+    "esp-alloc",
+    "esp32s3",
+] }
+
+esp-bootloader-esp-idf = { version = "0.4.0", features = ["log-04", "esp32s3"] }
+
+log = "0.4.27"
+
+embassy-executor = { version = "0.9.1", features = ["log"] }
+embassy-futures = "0.1"
+embassy-time = { version = "0.5.0", features = ["log"] }
+esp-alloc = { version = "0.9.0" }
+esp-backtrace = { version = "0.18.1", features = [
+    "println",
+    "esp32s3",
+    "panic-handler",
+] }
+esp-println = { version = "0.16.1", features = ["esp32s3", "log-04"] }
+
+embassy-sync = "0.7.2"
+static_cell = "2"
+critical-section = "1.2.0"
+
+[profile.dev]
+opt-level = "s"
+
+[profile.release]
+codegen-units = 1
+debug = 2
+debug-assertions = false
+incremental = false
+lto = 'fat'
+opt-level = 's'
+overflow-checks = false

--- a/firmware/sim-m5cores3/build.rs
+++ b/firmware/sim-m5cores3/build.rs
@@ -1,0 +1,70 @@
+fn main() {
+    linker_be_nice();
+    // make sure linkall.x is the last linker script (otherwise might cause problems with flip-link)
+    println!("cargo:rustc-link-arg=-Tlinkall.x");
+}
+
+fn linker_be_nice() {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() > 1 {
+        let kind = &args[1];
+        let what = &args[2];
+
+        match kind.as_str() {
+            "undefined-symbol" => match what.as_str() {
+                what if what.starts_with("_defmt_") => {
+                    eprintln!();
+                    eprintln!(
+                        "💡 `defmt` not found - make sure `defmt.x` is added as a linker script and you have included `use defmt_rtt as _;`"
+                    );
+                    eprintln!();
+                }
+                "_stack_start" => {
+                    eprintln!();
+                    eprintln!("💡 Is the linker script `linkall.x` missing?");
+                    eprintln!();
+                }
+                what if what.starts_with("esp_rtos_") => {
+                    eprintln!();
+                    eprintln!(
+                        "💡 `esp-radio` has no scheduler enabled. Make sure you have initialized `esp-rtos` or provided an external scheduler."
+                    );
+                    eprintln!();
+                }
+                "embedded_test_linker_file_not_added_to_rustflags" => {
+                    eprintln!();
+                    eprintln!(
+                        "💡 `embedded-test` not found - make sure `embedded-test.x` is added as a linker script for tests"
+                    );
+                    eprintln!();
+                }
+                "free"
+                | "malloc"
+                | "calloc"
+                | "get_free_internal_heap_size"
+                | "malloc_internal"
+                | "realloc_internal"
+                | "calloc_internal"
+                | "free_internal" => {
+                    eprintln!();
+                    eprintln!(
+                        "💡 Did you forget the `esp-alloc` dependency or didn't enable the `compat` feature on it?"
+                    );
+                    eprintln!();
+                }
+                _ => (),
+            },
+            // we don't have anything helpful for "missing-lib" yet
+            _ => {
+                std::process::exit(1);
+            }
+        }
+
+        std::process::exit(0);
+    }
+
+    println!(
+        "cargo:rustc-link-arg=-Wl,--error-handling-script={}",
+        std::env::current_exe().unwrap().display()
+    );
+}

--- a/firmware/sim-m5cores3/rust-toolchain.toml
+++ b/firmware/sim-m5cores3/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "esp"

--- a/firmware/sim-m5cores3/src/main.rs
+++ b/firmware/sim-m5cores3/src/main.rs
@@ -1,0 +1,219 @@
+#![no_std]
+#![no_main]
+#![deny(
+    clippy::mem_forget,
+    reason = "mem::forget is generally not safe to do with esp_hal types, especially those \
+    holding buffers for the duration of a data transfer."
+)]
+#![deny(clippy::large_stack_frames)]
+
+use core::cell::Cell;
+use core::sync::atomic::{AtomicI32, Ordering};
+
+use embassy_executor::Spawner;
+use embassy_futures::yield_now;
+use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
+use embassy_sync::signal::Signal;
+use embassy_time::{Delay, Duration, Instant, Ticker};
+use esp_hal::gpio::{Level, Output, OutputConfig};
+use esp_hal::i2c::master::{Config as I2cConfig, I2c};
+use esp_hal::interrupt::Priority;
+use esp_hal::interrupt::software::SoftwareInterruptControl;
+use esp_hal::spi::Mode as SpiMode;
+use esp_hal::spi::master::{Config as SpiConfig, Spi};
+use esp_hal::system::Stack;
+use esp_hal::time::Rate;
+use esp_hal::timer::timg::TimerGroup;
+use log::info;
+use ossm::{
+    CommandChannel, HomingSignal, MechanicalConfig, MotionController, MotionLimits, Motor,
+    MoveCompleteSignal, Ossm,
+};
+use pattern_engine::{Pattern, PatternCtx, PatternInput, SharedPatternInput, patterns::Deeper};
+use sim_m5cores3_board::{Display, FrameState, create_terminal, render_ui};
+use sim_motor::SimMotor;
+use static_cell::StaticCell;
+
+use esp_rtos::embassy::InterruptExecutor;
+
+use {esp_backtrace as _, esp_println as _};
+
+extern crate alloc;
+
+esp_bootloader_esp_idf::esp_app_desc!();
+
+const UPDATE_INTERVAL_SECS: f64 = 1.0 / 30.0;
+
+static COMMANDS: CommandChannel = CommandChannel::new();
+static HOMING_DONE: HomingSignal = HomingSignal::new();
+static MOVE_COMPLETE: MoveCompleteSignal = MoveCompleteSignal::new();
+static PATTERN_INPUT: SharedPatternInput = SharedPatternInput::new(Cell::new(PatternInput {
+    depth: 0.7,
+    stroke: 0.5,
+    velocity: 0.50,
+    sensation: -0.20,
+}));
+static MOTOR_POSITION: AtomicI32 = AtomicI32::new(0);
+
+static EXECUTOR_CORE_1: StaticCell<InterruptExecutor<2>> = StaticCell::new();
+static APP_CORE_STACK: StaticCell<Stack<16384>> = StaticCell::new();
+static MOTION_READY: Signal<CriticalSectionRawMutex, bool> = Signal::new();
+
+#[embassy_executor::task]
+async fn motion_task(mut controller: MotionController<'static, SimMotor>) {
+    let interval_us = (UPDATE_INTERVAL_SECS * 1_000_000.0) as u64;
+    let mut ticker = Ticker::every(Duration::from_micros(interval_us));
+
+    loop {
+        controller.update().await;
+        ticker.next().await;
+    }
+}
+
+#[embassy_executor::task]
+async fn display_task(mut display: Display, steps_per_mm: f64, min_mm: f64, max_mm: f64) {
+    let mut terminal = create_terminal(&mut display);
+    let range = max_mm - min_mm;
+    let mut last_frame = Instant::now();
+    let mut fps: u32 = 0;
+
+    loop {
+        let steps = MOTOR_POSITION.load(Ordering::Relaxed);
+        let mm = steps as f64 / steps_per_mm;
+        let position = if range > 0.0 {
+            let frac = (mm - min_mm) / range;
+            if frac < 0.0 {
+                0.0
+            } else if frac > 1.0 {
+                1.0
+            } else {
+                frac
+            }
+        } else {
+            0.0
+        };
+
+        let input = PATTERN_INPUT.lock(|cell| cell.get());
+
+        let state = FrameState {
+            position,
+            depth: input.depth,
+            stroke: input.stroke,
+            velocity: input.velocity,
+            sensation: input.sensation,
+            fps,
+            state: "Running",
+        };
+
+        let _ = terminal.draw(|frame| {
+            render_ui(frame, &state);
+        });
+
+        // Yield to let the pattern engine run on Core 0
+        yield_now().await;
+
+        let frame_time = last_frame.elapsed();
+        fps = (1_000_000 / frame_time.as_micros().max(1)) as u32;
+        last_frame = Instant::now();
+    }
+}
+
+#[esp_rtos::main]
+async fn main(spawner: Spawner) {
+    esp_println::logger::init_logger_from_env();
+
+    let config = esp_hal::Config::default().with_cpu_clock(esp_hal::clock::CpuClock::max());
+    let p = esp_hal::init(config);
+
+    esp_alloc::heap_allocator!(size: 200_000);
+
+    let timg0 = TimerGroup::new(p.TIMG0);
+    esp_rtos::start(timg0.timer0);
+
+    info!("Initializing M5Stack CoreS3 board...");
+
+    let i2c_config = I2cConfig::default().with_frequency(Rate::from_khz(400));
+    let mut i2c = I2c::new(p.I2C0, i2c_config)
+        .expect("Failed to initialize I2C")
+        .with_sda(p.GPIO12)
+        .with_scl(p.GPIO11);
+
+    // Enable display backlight
+    sim_m5cores3_board::pmu::init(&mut i2c);
+
+    let mut delay = esp_hal::delay::Delay::new();
+    sim_m5cores3_board::io_expander::init(&mut i2c, &mut delay);
+
+    let spi_config = SpiConfig::default()
+        .with_frequency(Rate::from_mhz(40))
+        .with_mode(SpiMode::_0);
+    let spi = Spi::new(p.SPI2, spi_config)
+        .expect("Failed to initialize SPI")
+        .with_mosi(p.GPIO37)
+        .with_sck(p.GPIO36);
+    let cs = Output::new(p.GPIO3, Level::High, OutputConfig::default());
+    let dc = Output::new(p.GPIO35, Level::Low, OutputConfig::default());
+
+    let display = sim_m5cores3_board::display::init(spi, cs, dc);
+
+    info!("Board initialization complete");
+
+    let motor = SimMotor::new(&MOTOR_POSITION);
+    let config = MechanicalConfig {
+        max_position_mm: 250.0,
+        ..MechanicalConfig::default()
+    };
+
+    let steps_per_mm = config.steps_per_mm(SimMotor::STEPS_PER_REV) as f64;
+
+    let (ossm, controller) = Ossm::new(
+        motor,
+        &config,
+        MotionLimits::default(),
+        UPDATE_INTERVAL_SECS,
+        &COMMANDS,
+        &HOMING_DONE,
+        &MOVE_COMPLETE,
+    );
+
+    let sw_int = SoftwareInterruptControl::new(p.SW_INTERRUPT);
+    let app_core_stack = APP_CORE_STACK.init(Stack::new());
+
+    let second_core = move || {
+        let executor = InterruptExecutor::new(sw_int.software_interrupt2);
+        let executor = EXECUTOR_CORE_1.init(executor);
+        let spawner = executor.start(Priority::Priority1);
+
+        spawner.spawn(motion_task(controller)).unwrap();
+
+        MOTION_READY.signal(true);
+
+        loop {}
+    };
+
+    esp_rtos::start_second_core(
+        p.CPU_CTRL,
+        sw_int.software_interrupt0,
+        sw_int.software_interrupt1,
+        app_core_stack,
+        second_core,
+    );
+
+    MOTION_READY.wait().await;
+
+    ossm.enable();
+    ossm.home().await;
+
+    spawner
+        .spawn(display_task(
+            display,
+            steps_per_mm,
+            config.min_position_mm,
+            config.max_position_mm,
+        ))
+        .unwrap();
+
+    let mut ctx = PatternCtx::new(&COMMANDS, &MOVE_COMPLETE, &PATTERN_INPUT, Delay);
+    let mut pattern = Deeper;
+    pattern.run(&mut ctx).await;
+}

--- a/justfile
+++ b/justfile
@@ -11,4 +11,11 @@ flash:
 build-wasm:
     wasm-pack build firmware/sim-wasm --target web
 
-build-all: build build-wasm
+build-m5cores3:
+    cargo +esp build -p sim-m5cores3 --target xtensa-esp32s3-none-elf -Z build-std=alloc,core --release
+
+flash-m5cores3:
+    cargo +esp build -p sim-m5cores3 --target xtensa-esp32s3-none-elf -Z build-std=alloc,core --release
+    espflash flash --monitor target/xtensa-esp32s3-none-elf/release/sim-m5cores3
+
+build-all: build build-wasm build-m5cores3


### PR DESCRIPTION
Problem: Testing and developing ossms requires bulky and attention grabbing hardware.

Solution: Create a small M5CoreS3 simulator to integrate with.

Notes: It should be able to run the sim motor, same as the wasm simulator.