### PR TITLE
chore(apps/simulator): Pin node version to current lts

### DIFF
--- a/apps/simulator/.nvmrc
+++ b/apps/simulator/.nvmrc
@@ -1,1 +1,1 @@
-lts/*
+lts/krypton

--- a/apps/simulator/package.json
+++ b/apps/simulator/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "engines": {
+    "node": ">=24 <25"
+  },
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",


### PR DESCRIPTION
## Problem

The node version is currently pinned to the latest lts which could introduce breaking changes when the new lts gets released.

## Solution

Pin configs and engines to current lts