### PR TITLE
feat(tooling): Adds just focus for rust analyzer build targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 /target
+rust-analyzer.toml
+
+# These get symlinked to support multi platform rust-analyzer
+/.cargo
+/rust-toolchain.toml
 
 NOTES.md

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,14 +1,16 @@
 {
-    "cSpell.words": [
-        "baudrate",
-        "espflash",
-        "espup",
-        "jtag",
-        "Ossm",
-        "println",
-        "UART",
-        "xtensa"
-    ],
-    "rust-analyzer.cargo.target": "xtensa-esp32s3-none-elf",
-    "rust-analyzer.cargo.allTargets": false
+  "cSpell.words": [
+    "baudrate",
+    "espflash",
+    "espup",
+    "jtag",
+    "Ossm",
+    "println",
+    "timg",
+    "UART",
+    "xtensa"
+  ],
+  "rust-analyzer.cfg.setTest": false,
+  "rust-analyzer.check.allTargets": false,
+  "rust-analyzer.check.workspace": false
 }

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,15 @@
+{
+  "lsp": {
+    "rust-analyzer": {
+      "initialization_options": {
+        "cfg": {
+          "setTest": false
+        },
+        "check": {
+          "allTargets": false,
+          "workspace": false
+        }
+      }
+    }
+  }
+}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,8 @@ debug = 2
 debug-assertions = false
 opt-level = 's'
 overflow-checks = false
+
+[profile.release.package.sim-wasm]
+codegen-units = 1
+opt-level = 's'
+strip = true

--- a/README.md
+++ b/README.md
@@ -148,6 +148,19 @@ Features are optional higher-level capabilities built on top of the core motion 
    cargo install just
    ```
 
+   Optionally, enable shell completions for `just` so you can tab-complete recipe names:
+
+   ```sh
+   # zsh (add to ~/.zshrc)
+   eval "$(just --completions zsh)"
+
+   # bash (add to ~/.bashrc)
+   eval "$(just --completions bash)"
+
+   # fish (add to ~/.config/fish/config.fish)
+   just --completions fish | source
+   ```
+
 4. **Install [espflash](https://github.com/esp-rs/espflash)** (for flashing firmware to the board):
 
    ```sh
@@ -160,6 +173,21 @@ Features are optional higher-level capabilities built on top of the core motion 
    just build
    just flash
    ```
+
+#### Configuring rust-analyzer
+
+This project targets multiple architectures (ESP32, ESP32-S3, WASM), each with its own Rust target triple and cargo features. Since rust-analyzer can only analyze one target at a time, it needs to be told which one to use - otherwise it defaults to your host platform and will report false errors for embedded or WASM code.
+
+The `just focus` command links a firmware's config tomls to the workspace root to configure the correct target and features:
+
+```sh
+just focus ossm-alt
+just focus wasm
+```
+
+After running this, you may need to restart rust-analyzer (or reload your editor) to pick up the new settings. You only need to re-run it when switching to a different target.
+
+> Note: In unix this uses a symlink, meaning if either file changes, both kept in sync. Windows has permission issues with symlinks, and so it performs a full copy instead. Edits to the root level configs will not be persisted, and can fall out of sync.
 
 #### In a dev container
 

--- a/firmware/ossm-alt/src/main.rs
+++ b/firmware/ossm-alt/src/main.rs
@@ -115,7 +115,7 @@ async fn main(spawner: Spawner) {
     let sw_int = SoftwareInterruptControl::new(p.SW_INTERRUPT);
     let app_core_stack = APP_CORE_STACK.init(Stack::new());
 
-    /// Run the motion controller interrupt on it's own core at high priority
+    // Run the motion controller interrupt on its own core at high priority
     let second_core = move || {
         let executor = InterruptExecutor::new(sw_int.software_interrupt2);
         let executor = EXECUTOR_CORE_1.init(executor);

--- a/firmware/sim-wasm/.cargo/config.toml
+++ b/firmware/sim-wasm/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target = "wasm32-unknown-unknown"

--- a/firmware/sim-wasm/Cargo.toml
+++ b/firmware/sim-wasm/Cargo.toml
@@ -16,3 +16,6 @@ wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 embassy-time = { version = "0.5.0", features = ["wasm", "generic-queue-32"] }
 critical-section = { version = "1.2", features = ["std"] }
+
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = ["-O", "--enable-bulk-memory", "--enable-nontrapping-float-to-int"]

--- a/firmware/sim-wasm/rust-toolchain.toml
+++ b/firmware/sim-wasm/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "stable"
+targets = ["wasm32-unknown-unknown"]

--- a/justfile
+++ b/justfile
@@ -3,30 +3,63 @@ set windows-shell := ["powershell.exe", "-NoLogo", "-c"]
 default:
     @just --list
 
-esp_target := "xtensa-esp32s3-none-elf"
-esp_flags := "--target " + esp_target + " -Z build-std=alloc,core --release"
-
-# OSSM Alt
+# OSSM Alt (ESP32-S3)
+[working-directory: 'firmware/ossm-alt']
 build-ossm-alt:
-    cargo +esp build -p ossm-alt {{esp_flags}}
+    cargo +esp build --release
 
-flash-ossm-alt: build-ossm-alt
-    espflash flash --monitor target/{{esp_target}}/release/ossm-alt
+[working-directory: 'firmware/ossm-alt']
+flash-ossm-alt:
+    cargo +esp run --release
 
-# M5CoreS3 Simulator
+# M5CoreS3 Simulator (ESP32-S3)
+[working-directory: 'firmware/sim-m5cores3']
 build-m5cores3:
-    cargo +esp build -p sim-m5cores3 {{esp_flags}}
-
-flash-m5cores3: build-m5cores3
-    espflash flash --monitor target/{{esp_target}}/release/sim-m5cores3
+    cargo +esp build --release
+    
+[working-directory: 'firmware/sim-m5cores3']
+flash-m5cores3:
+    cargo +esp run --release
 
 # WASM Simulator
 build-wasm:
     wasm-pack build firmware/sim-wasm --target web
 
 # Dev server (watches Rust sources and hot-reloads WASM)
+[working-directory: 'apps/simulator']
 dev-patterns: build-wasm
-    cd apps/simulator && pnpm dev
+    pnpm dev
 
 # All
+[parallel]
 build-all: build-ossm-alt build-wasm build-m5cores3
+
+# Focus rust-analyzer on a firmware crate by symlinking its .cargo to the workspace root
+[unix]
+focus crate:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ ! -d "firmware/{{ crate }}/.cargo" ]; then
+        echo "Error: firmware/{{ crate }}/.cargo does not exist"
+        exit 1
+    fi
+    if [ -d .cargo ] && [ ! -L .cargo ]; then
+        echo "Error: .cargo exists and is not a symlink, refusing to remove"
+        exit 1
+    fi
+    rm -f .cargo
+    ln -sn "firmware/{{ crate }}/.cargo" .cargo
+    ln -sn "firmware/{{ crate }}/rust-toolchain.toml" rust-toolchain.toml
+    echo "rust-analyzer focused on {{ crate }}"
+
+
+# Focus rust-analyzer on a firmware crate by copying its .cargo to the workspace root
+[windows]
+focus crate:
+    # Uses copy instead of symlink because symlinks on Windows require elevated privileges
+    if (-not (Test-Path "firmware/{{ crate }}/.cargo" -PathType Container)) { Write-Error "firmware/{{ crate }}/.cargo does not exist"; exit 1 }
+    if (Test-Path ".cargo") { Remove-Item ".cargo" -Recurse -Force }
+    if (Test-Path "rust-toolchain.toml") { Remove-Item "rust-toolchain.toml" -Force }
+    Copy-Item -Path "firmware/{{ crate }}/.cargo" -Destination ".cargo" -Recurse
+    Copy-Item -Path "firmware/{{ crate }}/rust-toolchain.toml" -Destination "rust-toolchain.toml"
+    Write-Host "rust-analyzer focused on {{ crate }}"


### PR DESCRIPTION
## Problem

rust-analyzer doesn't support multiple build targets, which this repository is by necessity. This is made less painful by the majority of the business code being no_std and multi target by design. There are still instances where building for specific targets is needed, mainly when building actual firmware or mcu specific features (like remotes built on top of a specific stack).

## Solution

Allow devs to "focus" rust analyzer easily by symlinking firmware .cargo and toolchain configs. On windows they are copied because of permission issues.

## Testing

Testing on the following OS to ensure good dev experience:

- [x] Mac
- [x] Windows
- [x] Linux (debian)

## Examples

```
$ just focus ossm-alt  
rust-analyzer focused on ossm-alt
```

```
$ just focus ossm-alter
Error: firmware/ossm-alter/.cargo does not exist
```