### PR TITLE
ci(windows): Adds github action to make sure just build-all works on windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,10 +37,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: esp-rs/xtensa-toolchain@v1.5
-        with:
-          default: true
-          ldproxy: false
-          cache: true
 
       - uses: Swatinem/rust-cache@v2
 
@@ -48,3 +44,36 @@ jobs:
 
       - name: Build ossm-alt
         run: just build-ossm-alt
+
+  build-windows:
+    name: Build on Windows
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: esp-rs/xtensa-toolchain@v1.5
+
+      - name: Export ESP environment
+        shell: pwsh
+        run: |
+          Get-Content "$env:USERPROFILE/exports" | ForEach-Object {
+            if ($_ -match '\$Env:PATH\s*=\s*"([^"]+)"') {
+              $path = $matches[1] -replace '\s*\+\s*\$Env:PATH', '' -replace '"', '' -replace ';$', ''
+              $path >> $env:GITHUB_PATH
+            }
+            elseif ($_ -match '\$Env:(\w+)\s*=\s*"([^"]+)"') {
+              $name = $matches[1]
+              $value = $matches[2]
+              "$name=$value" >> $env:GITHUB_ENV
+            }
+          }
+
+      - uses: Swatinem/rust-cache@v2
+
+      - uses: extractions/setup-just@v2
+
+      - name: Install wasm-pack
+        run: cargo install wasm-pack
+
+      - name: Build all
+        run: just build-all

--- a/justfile
+++ b/justfile
@@ -1,3 +1,5 @@
+set windows-shell := ["powershell.exe", "-NoLogo", "-c"]
+
 default:
     @just --list
 


### PR DESCRIPTION
## Problem

The current devs on this project run mac and linux, never windows. We want this project to be as dev friendly as possible, so we want to make sure we support windows too.

## Solution

Added a new `build-windows` job to the GitHub Actions CI workflow that runs on `windows-latest`. The job sets up the Xtensa toolchain, Rust cache, Just task runner, installs wasm-pack, and executes the full build process to ensure cross-platform compatibility.

## Testing

The Windows build job will be automatically tested on the next CI run and will verify that all build targets compile successfully on Windows.