### PR TITLE
refactor: Moved esp_log env var into .env

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,1 @@
+ESP_LOG=info

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ rust-analyzer.toml
 /.cargo
 /rust-toolchain.toml
 
-NOTES.md
+.env

--- a/README.md
+++ b/README.md
@@ -167,7 +167,15 @@ Features are optional higher-level capabilities built on top of the core motion 
    cargo install espflash
    ```
 
-5. You should now be able to build and flash:
+5. **(Optional) Enable dev features** by copying the sample environment file:
+
+   ```sh
+   cp .env.sample .env
+   ```
+
+   This sets `ESP_LOG=info` which enables runtime log output when flashing. You can change the log level in `.env` to `debug`, `warn`, `error`, etc.
+
+6. You should now be able to build and flash:
 
    ```sh
    just build

--- a/firmware/ossm-alt/.cargo/config.toml
+++ b/firmware/ossm-alt/.cargo/config.toml
@@ -5,8 +5,5 @@ rustflags = ["-C", "link-arg=-nostartfiles"]
 [target.xtensa-esp32s3-none-elf]
 runner = "espflash flash --monitor"
 
-[env]
-ESP_LOG = "info"
-
 [unstable]
 build-std = ["alloc", "core"]

--- a/firmware/sim-m5cores3/.cargo/config.toml
+++ b/firmware/sim-m5cores3/.cargo/config.toml
@@ -5,8 +5,5 @@ rustflags = ["-C", "link-arg=-nostartfiles"]
 [target.xtensa-esp32s3-none-elf]
 runner = "espflash flash --monitor"
 
-[env]
-ESP_LOG = "info"
-
 [unstable]
 build-std = ["alloc", "core"]

--- a/justfile
+++ b/justfile
@@ -1,4 +1,5 @@
 set windows-shell := ["powershell.exe", "-NoLogo", "-c"]
+set dotenv-load := true
 
 default:
     @just --list


### PR DESCRIPTION
## Problem

ESP logging configuration was hardcoded in cargo config files, making always enabled, even for release builds.

## Solution

Moved ESP_LOG configuration from hardcoded cargo config to an optional environment file system:

- Added `.env.sample` with default `ESP_LOG=info` setting
- Removed hardcoded `ESP_LOG = "info"` from both firmware cargo configs
- Enabled dotenv loading in justfile with `set dotenv-load := true`
- Added documentation for the optional environment setup step

Developers can now copy `.env.sample` to `.env` and customize their log level (debug, warn, error, etc.) without affecting the repository or other developers.

## Testing

Verified that builds work both with and without the `.env` file present, and that custom log levels in `.env` are properly applied during flashing.