### PR TITLE
feat(features/pattern-engine): Allow inter-movement input updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1453,6 +1453,7 @@ dependencies = [
  "embassy-sync 0.7.2",
  "embedded-hal 1.0.0",
  "heapless 0.9.2",
+ "log",
  "rsruckig",
 ]
 
@@ -1548,6 +1549,7 @@ dependencies = [
  "embassy-futures",
  "embassy-sync 0.7.2",
  "embedded-hal-async",
+ "log",
  "ossm",
 ]
 
@@ -1953,12 +1955,15 @@ version = "0.1.0"
 dependencies = [
  "critical-section",
  "embassy-time",
+ "js-sys",
+ "log",
  "ossm",
  "pattern-engine",
  "sim-board",
  "sim-motor",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ The project is split into several layers, each with a clear responsibility. Here
 
 ### Ossm (Public Control)
 
-`Ossm` is the public-facing API that features and application code interact with. On its own it doesn't do anything - it simply exposes methods like `enable()`, `disable()`, `home()`, `move_to()`, and `set_speed()` that accept fractional values (0.0-1.0) and forwards them over a lock-free channel to the motion controller. It's up to features (like the pattern engine or a controller) to call these methods and drive the machine.
+`Ossm` is the public-facing API that features and application code interact with. On its own it doesn't do anything - it simply exposes methods like `enable()`, `disable()`, `home()`, `pause()`, `resume()`, `begin_motion()`, `update_motion()`, and `await_motion()` that forward commands over a lock-free channel to the motion controller. It's up to features (like the pattern engine or a controller) to call these methods and drive the machine.
 
 ### Motion Controller
 

--- a/features/ossm-m5-remote/src/lib.rs
+++ b/features/ossm-m5-remote/src/lib.rs
@@ -270,35 +270,35 @@ async fn receiver_task(
             }
             M5Command::Speed => {
                 let velocity = (packet.value as f64) / config.max_velocity_mm_s;
-                engine.input().lock(|cell| {
-                    let mut input = cell.get();
-                    input.velocity = velocity.clamp(0.0, 1.0);
-                    cell.set(input);
+                engine.input().sender().send_modify(|opt| {
+                    if let Some(input) = opt {
+                        input.velocity = velocity.clamp(0.0, 1.0);
+                    }
                 });
             }
             M5Command::Depth => {
                 let depth = (packet.value as f64) / config.max_travel_mm;
-                engine.input().lock(|cell| {
-                    let mut input = cell.get();
-                    input.depth = depth.clamp(0.0, 1.0);
-                    cell.set(input);
+                engine.input().sender().send_modify(|opt| {
+                    if let Some(input) = opt {
+                        input.depth = depth.clamp(0.0, 1.0);
+                    }
                 });
             }
             M5Command::Stroke => {
                 let stroke = (packet.value as f64) / config.max_travel_mm;
-                engine.input().lock(|cell| {
-                    let mut input = cell.get();
-                    input.stroke = stroke.clamp(0.0, 1.0);
-                    cell.set(input);
+                engine.input().sender().send_modify(|opt| {
+                    if let Some(input) = opt {
+                        input.stroke = stroke.clamp(0.0, 1.0);
+                    }
                 });
             }
             M5Command::Sensation => {
                 // Remote sends -100..100; pattern engine expects -1.0..1.0
                 let sensation = ((packet.value as f64) / 100.0).clamp(-1.0, 1.0);
-                engine.input().lock(|cell| {
-                    let mut input = cell.get();
-                    input.sensation = sensation;
-                    cell.set(input);
+                engine.input().sender().send_modify(|opt| {
+                    if let Some(input) = opt {
+                        input.sensation = sensation;
+                    }
                 });
             }
             M5Command::Pattern => {

--- a/features/pattern-engine/Cargo.toml
+++ b/features/pattern-engine/Cargo.toml
@@ -8,3 +8,4 @@ ossm = { path = "../../ossm" }
 embassy-sync = { version = "0.7", default-features = false }
 embedded-hal-async = "1.0"
 embassy-futures = { version = "0.1", default-features = false }
+log = "0.4"

--- a/features/pattern-engine/src/engine.rs
+++ b/features/pattern-engine/src/engine.rs
@@ -1,4 +1,3 @@
-use core::cell::Cell;
 use core::sync::atomic::{AtomicU16, Ordering};
 
 use embassy_futures::select::{self, Either};
@@ -108,7 +107,7 @@ impl PatternEngine {
     pub const fn new(ossm: &'static Ossm) -> Self {
         Self {
             channels: PatternEngineChannels::new(),
-            input: SharedPatternInput::new(Cell::new(PatternInput::DEFAULT)),
+            input: SharedPatternInput::new_with(PatternInput::DEFAULT),
             ossm,
         }
     }

--- a/features/pattern-engine/src/input.rs
+++ b/features/pattern-engine/src/input.rs
@@ -1,7 +1,5 @@
-use core::cell::Cell;
-
-use embassy_sync::blocking_mutex::Mutex;
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
+use embassy_sync::watch::Watch;
 
 #[derive(Debug, Clone, Copy)]
 pub struct PatternInput {
@@ -31,4 +29,4 @@ impl Default for PatternInput {
     }
 }
 
-pub type SharedPatternInput = Mutex<CriticalSectionRawMutex, Cell<PatternInput>>;
+pub type SharedPatternInput = Watch<CriticalSectionRawMutex, PatternInput, 1>;

--- a/features/pattern-engine/src/pattern.rs
+++ b/features/pattern-engine/src/pattern.rs
@@ -1,3 +1,6 @@
+use embassy_futures::select::{self, Either};
+use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
+use embassy_sync::watch::Receiver;
 use embedded_hal_async::delay::DelayNs;
 use ossm::{Cancelled, MotionCommand, Ossm};
 
@@ -22,23 +25,33 @@ pub trait Pattern {
 pub struct PatternCtx<D: DelayNs> {
     ossm: &'static Ossm,
     input: &'static SharedPatternInput,
+    input_receiver: Receiver<'static, CriticalSectionRawMutex, PatternInput, 1>,
     delay: D,
 }
 
 impl<D: DelayNs> PatternCtx<D> {
     pub fn new(ossm: &'static Ossm, input: &'static SharedPatternInput, delay: D) -> Self {
-        Self { ossm, input, delay }
+        let input_receiver = input.receiver().expect("Watch receiver slot already taken");
+        Self {
+            ossm,
+            input,
+            input_receiver,
+            delay,
+        }
     }
 
     /// Read the current sensation value (-1.0 to 1.0).
     ///
     /// Re-read at each `.await` point to pick up live changes from BLE/UI.
     pub fn sensation(&self) -> f64 {
-        self.input.lock(|cell| cell.get()).sensation
+        self.input
+            .try_get()
+            .unwrap_or(PatternInput::DEFAULT)
+            .sensation
     }
 
     fn input(&self) -> PatternInput {
-        self.input.lock(|cell| cell.get())
+        self.input.try_get().unwrap_or(PatternInput::DEFAULT)
     }
 
     /// Start building a motion command.
@@ -50,17 +63,13 @@ impl<D: DelayNs> PatternCtx<D> {
     /// ctx.motion().position(1.0).send().await?;
     /// ctx.motion().position(0.5).speed(0.5).send().await?;
     /// ```
-    pub fn motion(&self) -> MotionBuilder<'_, D, NoPosition> {
+    pub fn motion(&mut self) -> MotionBuilder<'_, D, NoPosition> {
         MotionBuilder {
             ctx: self,
             position: NoPosition,
             speed_factor: 1.0,
             torque: None,
         }
-    }
-
-    async fn send_command(&self, cmd: MotionCommand) -> Result<(), Cancelled> {
-        self.ossm.push_motion(cmd).await
     }
 
     pub async fn delay_ms(&mut self, ms: u64) {
@@ -88,7 +97,7 @@ pub struct HasPosition(f64);
 /// Created via [`PatternCtx::motion()`]. Call `.position()` before `.send()` —
 /// the type system enforces this at compile time.
 pub struct MotionBuilder<'a, D: DelayNs, P> {
-    ctx: &'a PatternCtx<D>,
+    ctx: &'a mut PatternCtx<D>,
     position: P,
     speed_factor: f64,
     torque: Option<f64>,
@@ -126,19 +135,38 @@ impl<'a, D: DelayNs> MotionBuilder<'a, D, NoPosition> {
     }
 }
 
+fn compute_command(input: &PatternInput, fraction: f64, speed_factor: f64, torque: Option<f64>) -> MotionCommand {
+    let shallow = (input.depth - input.stroke).max(0.0);
+    let stroke = input.depth - shallow;
+    let position = shallow + fraction * stroke;
+    let speed = input.velocity * speed_factor;
+    MotionCommand {
+        position,
+        speed,
+        torque,
+    }
+}
+
 impl<'a, D: DelayNs> MotionBuilder<'a, D, HasPosition> {
     pub async fn send(self) -> Result<(), Cancelled> {
-        let input = self.ctx.input();
         let fraction = self.position.0.clamp(0.0, 1.0);
-        let shallow = input.depth - input.stroke;
-        let position = shallow + fraction * input.stroke;
-        let speed = input.velocity * self.speed_factor;
-        self.ctx
-            .send_command(MotionCommand {
-                position,
-                speed,
-                torque: self.torque,
-            })
-            .await
+        let speed_factor = self.speed_factor;
+        let torque = self.torque;
+
+        let input = self.ctx.input();
+        let cmd = compute_command(&input, fraction, speed_factor, torque);
+        self.ctx.ossm.begin_motion(cmd);
+
+        let mut move_done = core::pin::pin!(self.ctx.ossm.await_motion());
+
+        loop {
+            match select::select(move_done.as_mut(), self.ctx.input_receiver.changed()).await {
+                Either::First(result) => return result,
+                Either::Second(new_input) => {
+                    let cmd = compute_command(&new_input, fraction, speed_factor, torque);
+                    self.ctx.ossm.update_motion(cmd);
+                }
+            }
+        }
     }
 }

--- a/firmware/sim-m5cores3/src/main.rs
+++ b/firmware/sim-m5cores3/src/main.rs
@@ -91,7 +91,7 @@ async fn display_task(mut display: Display, steps_per_mm: f64, min_mm: f64, max_
             0.0
         };
 
-        let input = PATTERNS.input().lock(|cell| cell.get());
+        let input = PATTERNS.input().try_get().unwrap_or_default();
 
         let connected = ossm_m5_remote::is_connected();
         let pattern_idx = ossm_m5_remote::current_pattern() as usize;

--- a/firmware/sim-wasm/Cargo.toml
+++ b/firmware/sim-wasm/Cargo.toml
@@ -16,6 +16,9 @@ wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 embassy-time = { version = "0.5.0", features = ["wasm", "generic-queue-32"] }
 critical-section = { version = "1.2", features = ["std"] }
+log = "0.4"
+js-sys = "0.3"
+web-sys = { version = "0.3", features = ["console"] }
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = ["-O", "--enable-bulk-memory", "--enable-nontrapping-float-to-int"]

--- a/firmware/sim-wasm/src/lib.rs
+++ b/firmware/sim-wasm/src/lib.rs
@@ -85,37 +85,37 @@ impl Simulator {
 
     /// Set the maximum depth as a fraction of the machine range (0.0-1.0).
     pub fn set_depth(&self, depth: f64) {
-        PATTERNS.input().lock(|cell| {
-            let mut input = cell.get();
-            input.depth = depth;
-            cell.set(input);
+        PATTERNS.input().sender().send_modify(|opt| {
+            if let Some(input) = opt {
+                input.depth = depth;
+            }
         });
     }
 
     /// Set the stroke length as a fraction of the machine range (0.0-1.0).
     pub fn set_stroke(&self, stroke: f64) {
-        PATTERNS.input().lock(|cell| {
-            let mut input = cell.get();
-            input.stroke = stroke;
-            cell.set(input);
+        PATTERNS.input().sender().send_modify(|opt| {
+            if let Some(input) = opt {
+                input.stroke = stroke;
+            }
         });
     }
 
     /// Set velocity as a fraction of max velocity (0.0-1.0).
     pub fn set_velocity(&self, velocity: f64) {
-        PATTERNS.input().lock(|cell| {
-            let mut input = cell.get();
-            input.velocity = velocity;
-            cell.set(input);
+        PATTERNS.input().sender().send_modify(|opt| {
+            if let Some(input) = opt {
+                input.velocity = velocity;
+            }
         });
     }
 
     /// Set sensation value (-1.0 to 1.0). Meaning is pattern-specific.
     pub fn set_sensation(&self, sensation: f64) {
-        PATTERNS.input().lock(|cell| {
-            let mut input = cell.get();
-            input.sensation = sensation;
-            cell.set(input);
+        PATTERNS.input().sender().send_modify(|opt| {
+            if let Some(input) = opt {
+                input.sensation = sensation;
+            }
         });
     }
 

--- a/ossm/Cargo.toml
+++ b/ossm/Cargo.toml
@@ -11,3 +11,4 @@ rsruckig = { version = "2.1.3", default-features = false, features = [
 embassy-sync = { version = "0.7", default-features = false }
 embedded-hal = "1.0"
 heapless = "0.9.2"
+log = "0.4"

--- a/ossm/src/command.rs
+++ b/ossm/src/command.rs
@@ -2,7 +2,7 @@ use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_sync::channel::Channel;
 use embassy_sync::signal::Signal;
 
-pub(crate) type MoveChannel = Channel<CriticalSectionRawMutex, MoveCommand, 1>;
+pub(crate) type MoveChannel = Channel<CriticalSectionRawMutex, MotionCommand, 1>;
 pub(crate) type StateChannel = Channel<CriticalSectionRawMutex, StateCommand, 1>;
 pub(crate) type StateResponseSignal = Signal<CriticalSectionRawMutex, StateResponse>;
 pub(crate) type MoveResponseSignal = Signal<CriticalSectionRawMutex, Result<(), Cancelled>>;
@@ -36,20 +36,12 @@ pub struct MotionCommand {
 }
 
 #[derive(Debug, Clone, Copy)]
-pub(crate) enum MoveCommand {
-    MoveTo(f64),
-    Motion(MotionCommand),
-}
-
-#[derive(Debug, Clone, Copy)]
 pub enum StateCommand {
     Enable,
     Disable,
     Home,
     Pause,
     Resume,
-    SetSpeed(f64),
-    SetTorque(f64),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/ossm/src/lib.rs
+++ b/ossm/src/lib.rs
@@ -11,7 +11,7 @@ pub mod transport;
 
 pub use board::Board;
 pub use command::{Cancelled, MotionCommand, StateCommand, StateResponse};
-use command::{MoveCommand, OssmChannels};
+use command::OssmChannels;
 pub use limits::MotionLimits;
 pub use mechanical::MechanicalConfig;
 pub use motion::MotionController;
@@ -44,14 +44,6 @@ impl Ossm {
         MotionController::new(board, limits, update_interval_secs, &self.channels)
     }
 
-    /// Drain any pending move command, then send the new one and await completion.
-    async fn send_move(&self, cmd: MoveCommand) -> Result<(), Cancelled> {
-        self.channels.move_resp.reset();
-        let _ = self.channels.move_cmd.try_receive();
-        let _ = self.channels.move_cmd.try_send(cmd);
-        self.channels.move_resp.wait().await
-    }
-
     /// Send a state command and wait for the motion controller to respond.
     async fn send_state(&self, cmd: StateCommand) -> StateResponse {
         self.channels.state_resp.reset();
@@ -79,19 +71,24 @@ impl Ossm {
         self.send_state(StateCommand::Resume).await
     }
 
-    pub async fn set_speed(&self, speed: f64) -> StateResponse {
-        self.send_state(StateCommand::SetSpeed(speed)).await
+    /// Start a motion without waiting for completion.
+    ///
+    /// Resets the move response signal, so a subsequent [`await_motion`](Self::await_motion)
+    /// will wait for this move to finish.
+    pub fn begin_motion(&self, cmd: MotionCommand) {
+        self.channels.move_resp.reset();
+        let _ = self.channels.move_cmd.try_receive();
+        let _ = self.channels.move_cmd.try_send(cmd);
     }
 
-    pub async fn set_torque(&self, torque: f64) -> StateResponse {
-        self.send_state(StateCommand::SetTorque(torque)).await
+    /// Update the target of an in-flight motion without resetting the completion signal.
+    pub fn update_motion(&self, cmd: MotionCommand) {
+        let _ = self.channels.move_cmd.try_receive();
+        let _ = self.channels.move_cmd.try_send(cmd);
     }
 
-    pub async fn move_to(&self, position: f64) -> Result<(), Cancelled> {
-        self.send_move(MoveCommand::MoveTo(position)).await
-    }
-
-    pub async fn push_motion(&self, cmd: MotionCommand) -> Result<(), Cancelled> {
-        self.send_move(MoveCommand::Motion(cmd)).await
+    /// Wait for the current in-flight motion to complete.
+    pub async fn await_motion(&self) -> Result<(), Cancelled> {
+        self.channels.move_resp.wait().await
     }
 }

--- a/ossm/src/motion.rs
+++ b/ossm/src/motion.rs
@@ -1,6 +1,6 @@
 use rsruckig::prelude::*;
 
-use crate::command::{Cancelled, MoveCommand, OssmChannels, StateCommand, StateResponse};
+use crate::command::{Cancelled, MotionCommand, OssmChannels, StateCommand, StateResponse};
 use crate::{Board, MotionLimits};
 
 // Floor applied to velocity requests to prevent degenerate Ruckig inputs.
@@ -59,10 +59,6 @@ pub struct MotionController<'a, B: Board> {
     /// The last-instructed motion target. `Some` when a move has been commanded,
     /// `None` when there is no active motion intent (e.g. disabled, just homed).
     target: Option<MotionTarget>,
-    /// Default velocity used by `MoveTo` commands (mm/s).
-    default_speed: f64,
-    /// Default torque used by `MoveTo` commands.
-    default_torque: Option<f64>,
     ruckig: Ruckig<1, ThrowErrorHandler>,
     input: InputParameter<1>,
     output: OutputParameter<1>,
@@ -94,8 +90,6 @@ impl<'a, B: Board> MotionController<'a, B> {
             state: MotionState::Disabled,
             limits,
             target: None,
-            default_speed: MIN_VELOCITY,
-            default_torque: None,
             ruckig: Ruckig::<1, ThrowErrorHandler>::new(None, update_interval_secs),
             input,
             output: OutputParameter::new(None),
@@ -105,8 +99,7 @@ impl<'a, B: Board> MotionController<'a, B> {
     /// Advance the motion control loop by one step.
     ///
     /// Ticks the board, then the ruckig trajectory, then processes commands.
-    /// State commands are processed before move commands so that `SetSpeed`
-    /// applies before a `MoveTo` arriving in the same tick.
+    /// State commands are processed before move commands.
     pub async fn update(&mut self) {
         // 1. Let the board do periodic housekeeping (fault polling etc.)
         let _ = self.board.tick().await;
@@ -173,55 +166,21 @@ impl<'a, B: Board> MotionController<'a, B> {
                 self.respond(StateResponse::Completed);
             }
 
-            (_, StateCommand::SetSpeed(fraction)) => {
-                let vel = self.fraction_to_velocity(fraction);
-                self.default_speed = vel;
-                if matches!(self.state, MotionState::Moving) {
-                    if let Some(target) = &mut self.target {
-                        target.velocity = vel;
-                        self.sync_ruckig();
-                    }
-                }
-                self.respond(StateResponse::Completed);
-            }
-
-            (_, StateCommand::SetTorque(fraction)) => {
-                self.default_torque = Some(fraction);
-                if matches!(self.state, MotionState::Moving) {
-                    if let Some(target) = &mut self.target {
-                        target.torque = Some(fraction);
-                    }
-                    self.apply_torque().await;
-                }
-                self.respond(StateResponse::Completed);
-            }
-
             _ => {
                 self.respond(StateResponse::InvalidTransition);
             }
         }
     }
 
-    async fn process_move_command(&mut self, cmd: MoveCommand) {
-        match (&self.state, cmd) {
-            (MotionState::Ready, MoveCommand::MoveTo(fraction)) => {
-                let mm = self.fraction_to_mm(fraction);
-                self.set_target(|t| t.position = mm);
-                self.apply_torque().await;
-                self.state = MotionState::Moving;
-            }
-            (MotionState::Ready, MoveCommand::Motion(cmd)) => {
+    async fn process_move_command(&mut self, cmd: MotionCommand) {
+        match self.state {
+            MotionState::Ready => {
                 self.set_motion_target(cmd);
                 self.apply_torque().await;
                 self.state = MotionState::Moving;
             }
 
-            (MotionState::Moving, MoveCommand::MoveTo(fraction)) => {
-                let mm = self.fraction_to_mm(fraction);
-                self.set_target(|t| t.position = mm);
-                self.apply_torque().await;
-            }
-            (MotionState::Moving, MoveCommand::Motion(cmd)) => {
+            MotionState::Moving => {
                 self.set_motion_target(cmd);
                 self.apply_torque().await;
             }
@@ -328,17 +287,7 @@ impl<'a, B: Board> MotionController<'a, B> {
         mm_s.clamp(MIN_VELOCITY, self.limits.max_velocity_mm_s)
     }
 
-    fn set_target(&mut self, f: impl FnOnce(&mut MotionTarget)) {
-        let target = self.target.get_or_insert(MotionTarget {
-            position: self.input.current_position[0],
-            velocity: self.default_speed,
-            torque: self.default_torque,
-        });
-        f(target);
-        self.sync_ruckig();
-    }
-
-    fn set_motion_target(&mut self, cmd: crate::command::MotionCommand) {
+    fn set_motion_target(&mut self, cmd: MotionCommand) {
         self.target = Some(MotionTarget {
             position: self.fraction_to_mm(cmd.position),
             velocity: self.fraction_to_velocity(cmd.speed),
@@ -354,6 +303,7 @@ impl<'a, B: Board> MotionController<'a, B> {
             self.input.target_position[0] = target.position;
             self.input.max_velocity[0] = target.velocity;
             self.output.time = 0.0;
+            self.ruckig.reset();
         }
     }
 


### PR DESCRIPTION
## Problem

The pattern engine's motion system was blocking during movement execution, preventing real-time updates to motion parameters from user input or remote control commands.

## Solution

Clean up the ossm apis:

- State: `enable`, `disable`, `home`, `pause`, `resume`
- Motion: `begin_motion`, `update_motion`, `await_motion`

The new motion apis don't hide what is going on under the hood: the motion you sent may be modified but you can still listen to when that motion is finished.

The other path I toyed with was returning a superseded(next_movement) so you could keep track of them but it became far too convoluted.

## Testing

Tested with the WASM simulator to verify that velocity, depth, stroke, and sensation parameters can be adjusted during pattern execution without interrupting motion flow.

Closes #20