### PR TITLE
feat(logging): Unify logging for better debugging

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,1 +1,0 @@
-ESP_LOG=info

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1452,6 +1452,7 @@ version = "0.1.0"
 dependencies = [
  "crc",
  "embassy-sync 0.7.2",
+ "embassy-time",
  "embedded-hal 1.0.0",
  "embedded-hal-async",
  "embedded-io 0.7.1",

--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ Features are optional higher-level capabilities built on top of the core motion 
    cargo install espflash
    ```
 
+<<<<<<< HEAD
 5. **(Optional) Enable dev features** by copying the sample environment file:
 
    ```sh
@@ -174,6 +175,9 @@ Features are optional higher-level capabilities built on top of the core motion 
    This sets `ESP_LOG=info` which enables runtime log output when flashing. You can change the log level in `.env` to `debug`, `warn`, `error`, etc.
 
 6. You should now be able to build and flash for your board:
+=======
+5. You should now be able to build and flash:
+>>>>>>> 452db1e (feat(logging): Unify logging for better debugging)
 
    ```sh
    just build-ossm-alt    # OSSM Alt Edition

--- a/firmware/ossm-alt/Cargo.toml
+++ b/firmware/ossm-alt/Cargo.toml
@@ -33,7 +33,7 @@ esp-rtos = { version = "0.2.0", features = [
 
 esp-bootloader-esp-idf = { version = "0.4.0", features = ["log-04", "esp32s3"] }
 
-log = "0.4.27"
+log = { version = "0.4.27", features = ["release_max_level_info"] }
 
 embassy-executor = { version = "0.9.1", features = ["log"] }
 embassy-time = { version = "0.5.0", features = ["log"] }

--- a/firmware/ossm-alt/src/main.rs
+++ b/firmware/ossm-alt/src/main.rs
@@ -77,7 +77,9 @@ async fn motion_task(mut controller: MotionController<'static, ConcreteBoard>) {
 
 #[esp_rtos::main]
 async fn main(spawner: Spawner) {
-    esp_println::logger::init_logger_from_env();
+    ossm::logging::init(log::LevelFilter::Info, |line| {
+        esp_println::println!("{}", line);
+    });
 
     let p = esp_hal::init(esp_hal::Config::default());
 

--- a/firmware/sim-m5cores3/Cargo.toml
+++ b/firmware/sim-m5cores3/Cargo.toml
@@ -31,7 +31,7 @@ esp-rtos = { version = "0.2.0", features = [
 
 esp-bootloader-esp-idf = { version = "0.4.0", features = ["log-04", "esp32s3"] }
 
-log = "0.4.27"
+log = { version = "0.4.27", features = ["release_max_level_info"] }
 
 embassy-executor = { version = "0.9.1", features = ["log"] }
 embassy-futures = "0.1"

--- a/firmware/sim-m5cores3/src/main.rs
+++ b/firmware/sim-m5cores3/src/main.rs
@@ -127,7 +127,9 @@ async fn display_task(mut display: Display, steps_per_mm: f64, min_mm: f64, max_
 
 #[esp_rtos::main]
 async fn main(spawner: Spawner) {
-    esp_println::logger::init_logger_from_env();
+    ossm::logging::init(log::LevelFilter::Info, |line| {
+        esp_println::println!("{}", line);
+    });
 
     let config = esp_hal::Config::default().with_cpu_clock(esp_hal::clock::CpuClock::max());
     let p = esp_hal::init(config);

--- a/firmware/sim-wasm/Cargo.toml
+++ b/firmware/sim-wasm/Cargo.toml
@@ -16,7 +16,7 @@ wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 embassy-time = { version = "0.5.0", features = ["wasm", "generic-queue-32"] }
 critical-section = { version = "1.2", features = ["std"] }
-log = "0.4"
+log = { version = "0.4", features = ["release_max_level_info"] }
 js-sys = "0.3"
 web-sys = { version = "0.3", features = ["console"] }
 

--- a/firmware/sim-wasm/src/lib.rs
+++ b/firmware/sim-wasm/src/lib.rs
@@ -33,6 +33,10 @@ impl Simulator {
     /// `update_interval_ms` controls the motion controller tick rate (e.g. 10.0 for 10ms).
     #[wasm_bindgen(constructor)]
     pub fn new(update_interval_ms: f64) -> Self {
+        ossm::logging::init(log::LevelFilter::Info, |line| {
+            web_sys::console::log_1(&wasm_bindgen::JsValue::from_str(line));
+        });
+
         let update_interval_secs = update_interval_ms / 1000.0;
         let motor = SimMotor::new(&MOTOR_POSITION);
         let board = SimBoard::new(motor, &MECHANICAL);

--- a/ossm/Cargo.toml
+++ b/ossm/Cargo.toml
@@ -9,6 +9,7 @@ rsruckig = { version = "2.1.3", default-features = false, features = [
     "alloc",
 ] }
 embassy-sync = { version = "0.7", default-features = false }
+embassy-time = { version = "0.5", default-features = false }
 embedded-hal = "1.0"
 embedded-hal-async = "1.0"
 embedded-io = "0.7.1"

--- a/ossm/src/lib.rs
+++ b/ossm/src/lib.rs
@@ -4,6 +4,7 @@ extern crate alloc;
 mod board;
 mod command;
 mod limits;
+pub mod logging;
 mod mechanical;
 mod motion;
 mod motor;

--- a/ossm/src/logging.rs
+++ b/ossm/src/logging.rs
@@ -1,0 +1,69 @@
+use core::fmt::Write;
+use core::sync::atomic::{AtomicPtr, Ordering};
+
+use embassy_time::Instant;
+
+/// Output function type: receives a fully formatted log line.
+type WriteFn = fn(&str);
+
+static WRITE_FN: AtomicPtr<()> = AtomicPtr::new(core::ptr::null_mut());
+
+struct OssmLogger;
+
+impl log::Log for OssmLogger {
+    fn enabled(&self, _metadata: &log::Metadata) -> bool {
+        !WRITE_FN.load(Ordering::Relaxed).is_null()
+    }
+
+    fn log(&self, record: &log::Record) {
+        let write_fn = WRITE_FN.load(Ordering::Relaxed);
+        if write_fn.is_null() {
+            return;
+        }
+        let write_fn: WriteFn = unsafe { core::mem::transmute(write_fn) };
+
+        let elapsed = Instant::now().as_millis();
+        let hours = elapsed / 3_600_000;
+        let minutes = (elapsed % 3_600_000) / 60_000;
+        let seconds = (elapsed % 60_000) / 1_000;
+        let millis = elapsed % 1_000;
+
+        let mut buf = heapless::String::<256>::new();
+        let _ = write!(
+            buf,
+            "[{:02}:{:02}:{:02}.{:03}] [{:<5}] [{}] {}",
+            hours,
+            minutes,
+            seconds,
+            millis,
+            record.level(),
+            record.target(),
+            record.args(),
+        );
+
+        write_fn(buf.as_str());
+    }
+
+    fn flush(&self) {}
+}
+
+static LOGGER: OssmLogger = OssmLogger;
+
+/// Initialize the OSSM logger.
+///
+/// `write` receives a fully formatted log line and is responsible for
+/// outputting it (e.g. UART, USB, console). The line does **not** include
+/// a trailing newline — the write function should add one if needed.
+///
+/// # Example
+///
+/// ```ignore
+/// ossm::logging::init(log::LevelFilter::Info, |line| {
+///     esp_println::println!("{}", line);
+/// });
+/// ```
+pub fn init(max_level: log::LevelFilter, write: WriteFn) {
+    WRITE_FN.store(write as *mut (), Ordering::Relaxed);
+    log::set_logger(&LOGGER).ok();
+    log::set_max_level(max_level);
+}


### PR DESCRIPTION
## Problem

Logging is sporadic making debugging logs difficult.

## Solution

Created a unified logging solution for each firmware which include useful information.

```
[00:00:00.123] [INFO ] [ossm_alt] Motion task started on core 1 at 20ms interval
[00:01:23.456] [ERROR] [pattern_engine::engine] Board fault during pause
```

Time since power on, log level, crate, message.

Removes the need for the .env as logging levels are now hard coded.

## Testing

Tested on the ossm-alt, logs came through correctly.