### PR TITLE
docs: adds a `just doctor` command to check environments

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,4 +1,5 @@
-set windows-shell := ["powershell.exe", "-NoLogo", "-c"]
+set windows-shell := ["powershell.exe", "-NoLogo", "-c", "if (Test-Path \"$env:USERPROFILE\\export-esp.ps1\") { . \"$env:USERPROFILE\\export-esp.ps1\" };"]
+set shell := ["bash", "-c", ". $HOME/export-esp.sh 2>/dev/null; eval \"$0\""]
 set dotenv-load := true
 
 default:
@@ -34,6 +35,15 @@ dev-patterns: build-wasm
 # All
 [parallel]
 build-all: build-ossm-alt build-wasm build-m5cores3
+
+# Check that all required tools are installed
+[unix]
+doctor:
+    scripts/doctor.sh
+
+[windows]
+doctor:
+    powershell.exe -NoLogo -ExecutionPolicy Bypass -File scripts/doctor.ps1
 
 # Focus rust-analyzer on a firmware crate by symlinking its .cargo to the workspace root
 [unix]

--- a/scripts/doctor.ps1
+++ b/scripts/doctor.ps1
@@ -1,0 +1,75 @@
+$ok = $true
+
+function Get-ToolVersion($cmd) {
+    try { @(& $cmd --version 2>$null)[0] } catch { "" }
+}
+
+function Check($name, $reason) {
+    $found = Get-Command $name -ErrorAction SilentlyContinue
+    if ($found) {
+        $ver = Get-ToolVersion $name
+        Write-Host "  + " -ForegroundColor Green -NoNewline
+        Write-Host ("{0,-12} {1}" -f $name, $ver)
+    } else {
+        Write-Host "  x " -ForegroundColor Red -NoNewline
+        Write-Host ("{0,-12} {1}" -f $name, $reason)
+        $script:ok = $false
+    }
+}
+
+function CheckOptional($name, $reason) {
+    $found = Get-Command $name -ErrorAction SilentlyContinue
+    if ($found) {
+        $ver = Get-ToolVersion $name
+        Write-Host "  + " -ForegroundColor Green -NoNewline
+        Write-Host ("{0,-12} {1}" -f $name, $ver)
+    } else {
+        Write-Host "  ~ " -ForegroundColor Yellow -NoNewline
+        Write-Host ("{0,-12} {1} (optional)" -f $name, $reason)
+    }
+}
+
+function CheckEspToolchain() {
+    $espVer = @(& cargo +esp --version 2>&1)[0]
+    if ($LASTEXITCODE -eq 0) {
+        Write-Host "  + " -ForegroundColor Green -NoNewline
+        Write-Host ("{0,-12} {1}" -f "+esp", $espVer)
+    } else {
+        Write-Host "  x " -ForegroundColor Red -NoNewline
+        Write-Host ("{0,-12} {1}" -f "+esp", "needed to cross-compile for ESP32 targets")
+        $script:ok = $false
+    }
+}
+
+function CheckExportEsp() {
+    $exportPath = Join-Path $env:USERPROFILE "export-esp.ps1"
+    if (Test-Path $exportPath) {
+        Write-Host "  + " -ForegroundColor Green -NoNewline
+        Write-Host "~/export-esp.ps1"
+    } else {
+        Write-Host "  x " -ForegroundColor Red -NoNewline
+        Write-Host "~/export-esp.ps1 not found - needed to set ESP toolchain paths"
+        $script:ok = $false
+    }
+}
+
+Write-Host "Firmware..."
+Check cargo            "needed to compile Rust crates"
+Check espup            "needed to install the ESP Rust toolchain"
+Check espflash         "needed to flash firmware to ESP32 boards"
+CheckEspToolchain
+CheckExportEsp
+
+Write-Host ""
+Write-Host "Web simulator..."
+Check node             "needed as the JS runtime for pnpm"
+Check pnpm             "needed to run the web simulator dev server"
+Check wasm-pack        "needed to build the WASM simulator"
+
+Write-Host ""
+if ($ok) {
+    Write-Host "All good!" -ForegroundColor Green
+} else {
+    Write-Host "Some tools are missing. See above for details." -ForegroundColor Red
+    exit 1
+}

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ok=true
+
+version() {
+    "$1" --version 2>/dev/null | head -1
+}
+
+check() {
+    if command -v "$1" &>/dev/null; then
+        printf '  \033[32m✓\033[0m %-12s %s\n' "$1" "$(version "$1")"
+    else
+        printf '  \033[31m✗\033[0m %-12s %s\n' "$1" "$2"
+        ok=false
+    fi
+}
+
+check_optional() {
+    if command -v "$1" &>/dev/null; then
+        printf '  \033[32m✓\033[0m %-12s %s\n' "$1" "$(version "$1")"
+    else
+        printf '  \033[33m~\033[0m %-12s %s (optional)\n' "$1" "$2"
+    fi
+}
+
+check_esp_toolchain() {
+    if cargo +esp --version &>/dev/null; then
+        printf '  \033[32m✓\033[0m %-12s %s\n' "+esp" "$(cargo +esp --version 2>/dev/null | head -1)"
+    else
+        printf '  \033[31m✗\033[0m %-12s %s\n' "+esp" "needed to cross-compile for ESP32 targets"
+        ok=false
+    fi
+}
+
+check_export_esp() {
+    if [ -f "$HOME/export-esp.sh" ]; then
+        printf '  \033[32m✓\033[0m ~/export-esp.sh\n'
+    else
+        printf '  \033[31m✗\033[0m ~/export-esp.sh not found - needed to set ESP toolchain paths\n'
+        ok=false
+    fi
+}
+
+# nvm is a shell function, not a binary - check for its install directory instead
+check_nvm() {
+    if [ -d "${NVM_DIR:-$HOME/.nvm}" ]; then
+        nvm_ver=""
+        if [ -f "${NVM_DIR:-$HOME/.nvm}/nvm.sh" ]; then
+            # shellcheck disable=SC1091
+            . "${NVM_DIR:-$HOME/.nvm}/nvm.sh" 2>/dev/null
+            nvm_ver="$(nvm --version 2>/dev/null)"
+        fi
+        printf '  \033[32m✓\033[0m %-12s %s\n' "nvm" "${nvm_ver:-installed}"
+    else
+        printf '  \033[33m~\033[0m %-12s %s (optional)\n' "nvm" "manages Node.js versions"
+    fi
+}
+
+echo "Firmware..."
+check cargo            "needed to compile Rust crates"
+check espup            "needed to install the ESP Rust toolchain"
+check espflash         "needed to flash firmware to ESP32 boards"
+check_esp_toolchain
+check_export_esp
+
+echo ""
+echo "Web simulator..."
+check_nvm
+check node             "needed as the JS runtime for pnpm"
+check pnpm             "needed to run the web simulator dev server"
+check wasm-pack        "needed to build the WASM simulator"
+
+echo ""
+if $ok; then
+    printf '\033[32mAll good!\033[0m\n'
+else
+    printf '\033[31mSome tools are missing. See above for install instructions.\033[0m\n'
+    exit 1
+fi


### PR DESCRIPTION
## Problem

Contributors are having issues building this project. The esp toolchain requires you to source an esp export file which is easy to forget.

<!-- What issue does this solve? Link any relevant issues. -->

## Solution

<!-- How does this PR solve the problem? -->

Add a `just doctor` command that checks your environment for readiness and lists installed versions for bug reports. It also automatically sources the esp_export file if it exists.

## Testing

- [x] Unix
- [ ] Windows

<!-- How was this tested? -->

## Screenshots

```
➜  ossm git:(03-19-docs_adds_a_just_doctor_command_to_check_environments) just doctor
scripts/doctor.sh
Firmware...
  ✓ cargo        cargo 1.94.0 (85eff7c80 2026-01-15)
  ✓ espup        espup 0.16.0
  ✓ espflash     espflash 4.3.0
  ✓ +esp         cargo 1.93.0-nightly (083ac5135 2025-12-15) (1.93.0.0)
  ✓ ~/export-esp.sh

Web simulator...
  ✓ node         v24.14.0
  ✓ pnpm         10.30.3
  ✓ wasm-pack    wasm-pack 0.14.0
  ✓ nvm          0.40.4

All good!
```