### PR TITLE
feat(pattern-engine): Expose pattern state updates

### DIFF
--- a/features/pattern-engine/src/any_pattern_macro.rs
+++ b/features/pattern-engine/src/any_pattern_macro.rs
@@ -4,8 +4,8 @@
 /// For each entry this produces:
 /// - An `AnyPattern` enum variant wrapping the pattern type.
 /// - A `From<Type>` impl for converting into `AnyPattern`.
-/// - Delegation of every `Pattern` trait method to the inner type.
-/// - `BUILTIN_NAMES`: array of display names pulled from each type's `Pattern::NAME`.
+/// - Delegation of `Pattern::run()` to the inner type.
+/// - `BUILTIN_PATTERNS`: array of [`PatternMeta`] for each variant.
 /// - `all_builtin()`: array of default-constructed `AnyPattern` instances.
 ///
 /// ```ignore
@@ -21,8 +21,8 @@ macro_rules! define_patterns {
         }
 
         impl AnyPattern {
-            pub const BUILTIN_NAMES: [&'static str; define_patterns!(@count $($variant)+)] = [
-                $( $type::NAME, )+
+            pub const BUILTIN_PATTERNS: [PatternMeta; define_patterns!(@count $($variant)+)] = [
+                $( PatternMeta { name: $type::NAME, description: $type::DESCRIPTION }, )+
             ];
 
             pub fn all_builtin() -> [AnyPattern; define_patterns!(@count $($variant)+)] {
@@ -33,14 +33,6 @@ macro_rules! define_patterns {
         impl Pattern for AnyPattern {
             const NAME: &'static str = "AnyPattern";
             const DESCRIPTION: &'static str = "Enum dispatch wrapper";
-
-            fn name(&self) -> &'static str {
-                match self { $( Self::$variant(p) => p.name(), )+ }
-            }
-
-            fn description(&self) -> &'static str {
-                match self { $( Self::$variant(p) => p.description(), )+ }
-            }
 
             async fn run(&mut self, ctx: &mut PatternCtx<impl DelayNs>) -> Result<(), ossm::Cancelled> {
                 match self { $( Self::$variant(p) => p.run(ctx).await, )+ }

--- a/features/pattern-engine/src/engine.rs
+++ b/features/pattern-engine/src/engine.rs
@@ -3,6 +3,7 @@ use core::sync::atomic::{AtomicU16, Ordering};
 use embassy_futures::select::{self, Either};
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_sync::channel::Channel;
+use embassy_sync::pubsub::{self, PubSubChannel};
 use embedded_hal_async::delay::DelayNs;
 use ossm::{Ossm, StateResponse};
 
@@ -68,6 +69,17 @@ impl EngineState {
     }
 }
 
+/// Broadcast channel for [`EngineState`].
+///
+/// Uses `PubSubChannel` so subscribers can be created and dropped
+/// dynamically as services start and stop.
+///
+/// - `CAP = 1`: only the latest transition matters; older messages are dropped.
+/// - `SUBS = 8`: up to 8 concurrent async subscribers.
+/// - `PUBS = 0`: publishing uses [`PubSubChannel::immediate_publisher()`]
+///   which does not consume a publisher slot.
+type StateChannel = PubSubChannel<CriticalSectionRawMutex, EngineState, 1, 8, 0>;
+
 struct PatternEngineChannels {
     commands: EngineCommandChannel,
     state: AtomicU16,
@@ -100,6 +112,7 @@ impl PatternEngineChannels {
 pub struct PatternEngine {
     channels: PatternEngineChannels,
     input: SharedPatternInput,
+    state_channel: StateChannel,
     ossm: &'static Ossm,
 }
 
@@ -108,12 +121,32 @@ impl PatternEngine {
         Self {
             channels: PatternEngineChannels::new(),
             input: SharedPatternInput::new_with(PatternInput::DEFAULT),
+            state_channel: StateChannel::new(),
             ossm,
         }
     }
 
     pub fn input(&self) -> &SharedPatternInput {
         &self.input
+    }
+
+    /// Create an async subscriber that receives [`EngineState`] on every
+    /// state transition.
+    ///
+    /// Returns `Err` if all subscriber slots are in use.
+    ///
+    /// ```ignore
+    /// let mut sub = engine.state_subscriber()?;
+    /// loop {
+    ///     let state = sub.next_message_pure().await;
+    ///     // react to state change …
+    /// }
+    /// ```
+    pub fn state_subscriber(
+        &self,
+    ) -> Result<pubsub::Subscriber<'_, CriticalSectionRawMutex, EngineState, 1, 8, 0>, pubsub::Error>
+    {
+        self.state_channel.subscriber()
     }
 
     pub fn runner<const N: usize>(
@@ -132,7 +165,6 @@ impl PatternEngine {
     }
 
     pub fn play(&self, index: usize) {
-        self.channels.store(EngineState::Playing(index));
         let _ = self.channels.commands.try_send(EngineCommand::Play(index));
     }
 
@@ -154,6 +186,12 @@ impl PatternEngine {
 
     pub fn state(&self) -> EngineState {
         self.channels.state()
+    }
+
+    fn publish_state(&self, state: EngineState) {
+        self.state_channel
+            .immediate_publisher()
+            .publish_immediate(state);
     }
 }
 
@@ -233,6 +271,9 @@ impl<const N: usize> PatternEngineRunner<N> {
 
                     // Split borrows: the pinned future holds `patterns[idx]`,
                     // so we access `engine` and `state` through separate refs.
+                    // This also means we cannot call `set_state()` here, so
+                    // transitions publish state directly via
+                    // `engine.publish_state()`.
                     let engine = self.engine;
                     let state = &mut self.state;
                     let pattern_fut = core::pin::pin!(self.patterns[idx].run(&mut ctx));
@@ -250,6 +291,7 @@ impl<const N: usize> PatternEngineRunner<N> {
                                 if matches!(*state, RunnerState::Playing(_)) {
                                     *state = RunnerState::Idle;
                                     engine.channels.store(EngineState::Idle);
+                                    engine.publish_state(EngineState::Idle);
                                 }
                                 break;
                             }
@@ -259,31 +301,38 @@ impl<const N: usize> PatternEngineRunner<N> {
                                         log::error!("Pause failed, stopping engine");
                                         *state = RunnerState::Idle;
                                         engine.channels.store(EngineState::Idle);
+                                        engine.publish_state(EngineState::Idle);
                                         break;
                                     }
                                     engine.channels.store(EngineState::Paused(idx));
+                                    engine.publish_state(EngineState::Paused(idx));
                                 }
                                 EngineCommand::Resume => {
                                     if ossm.resume().await != StateResponse::Completed {
                                         log::error!("Resume failed, stopping engine");
                                         *state = RunnerState::Idle;
                                         engine.channels.store(EngineState::Idle);
+                                        engine.publish_state(EngineState::Idle);
                                         break;
                                     }
                                     engine.channels.store(EngineState::Playing(idx));
+                                    engine.publish_state(EngineState::Playing(idx));
                                 }
                                 EngineCommand::Play(i) if i == idx => {
                                     if ossm.resume().await != StateResponse::Completed {
                                         log::error!("Resume failed, stopping engine");
                                         *state = RunnerState::Idle;
                                         engine.channels.store(EngineState::Idle);
+                                        engine.publish_state(EngineState::Idle);
                                         break;
                                     }
                                     engine.channels.store(EngineState::Playing(idx));
+                                    engine.publish_state(EngineState::Playing(idx));
                                 }
                                 EngineCommand::Play(new_idx) if new_idx < N => {
                                     *state = RunnerState::Playing(new_idx);
                                     engine.channels.store(EngineState::Playing(new_idx));
+                                    engine.publish_state(EngineState::Playing(new_idx));
                                     break;
                                 }
                                 EngineCommand::Stop => {
@@ -292,6 +341,7 @@ impl<const N: usize> PatternEngineRunner<N> {
                                     }
                                     *state = RunnerState::Idle;
                                     engine.channels.store(EngineState::Idle);
+                                    engine.publish_state(EngineState::Idle);
                                     break;
                                 }
                                 _ => {}
@@ -305,7 +355,9 @@ impl<const N: usize> PatternEngineRunner<N> {
 
     fn set_state(&mut self, state: RunnerState) {
         self.state = state;
-        self.engine.channels.store(state.as_engine_state());
+        let engine_state = state.as_engine_state();
+        self.engine.channels.store(engine_state);
+        self.engine.publish_state(engine_state);
     }
 
     async fn handle_command(&mut self, cmd: EngineCommand) {

--- a/features/pattern-engine/src/lib.rs
+++ b/features/pattern-engine/src/lib.rs
@@ -11,6 +11,13 @@ pub use input::{PatternInput, SharedPatternInput};
 pub use pattern::{Pattern, PatternCtx};
 pub use util::scale;
 
+/// Public-facing metadata for a pattern.
+#[derive(Debug, Clone, Copy)]
+pub struct PatternMeta {
+    pub name: &'static str,
+    pub description: &'static str,
+}
+
 use embedded_hal_async::delay::DelayNs;
 
 use crate::patterns::{Deeper, HalfHalf, NonePattern, Simple, StopNGo, TeasingPounding, Torque};
@@ -21,7 +28,7 @@ use crate::patterns::{Deeper, HalfHalf, NonePattern, Simple, StopNGo, TeasingPou
 // 3. Add a `Variant(Type)` entry below.
 //
 // The macro generates the `AnyPattern` enum, `Pattern` trait delegation,
-// `From` impls, `BUILTIN_NAMES`, and `all_builtin()`.
+// `From` impls, `BUILTIN_PATTERNS`, and `all_builtin()`.
 // See `any_pattern_macro.rs` for the full definition.
 include!("any_pattern_macro.rs");
 

--- a/features/pattern-engine/src/pattern.rs
+++ b/features/pattern-engine/src/pattern.rs
@@ -20,14 +20,6 @@ pub trait Pattern {
     const NAME: &'static str;
     const DESCRIPTION: &'static str;
 
-    fn name(&self) -> &'static str {
-        Self::NAME
-    }
-
-    fn description(&self) -> &'static str {
-        Self::DESCRIPTION
-    }
-
     async fn run(&mut self, ctx: &mut PatternCtx<impl DelayNs>) -> Result<(), Cancelled>;
 }
 

--- a/firmware/sim-m5cores3/src/main.rs
+++ b/firmware/sim-m5cores3/src/main.rs
@@ -97,9 +97,9 @@ async fn display_task(mut display: Display, steps_per_mm: f64, min_mm: f64, max_
 
         let connected = ossm_m5_remote::is_connected();
         let pattern_idx = ossm_m5_remote::current_pattern() as usize;
-        let pattern_name = AnyPattern::BUILTIN_NAMES
+        let pattern_name = AnyPattern::BUILTIN_PATTERNS
             .get(pattern_idx)
-            .copied()
+            .map(|p| p.name)
             .unwrap_or("Unknown");
         let state = FrameState {
             position,

--- a/firmware/sim-wasm/src/lib.rs
+++ b/firmware/sim-wasm/src/lib.rs
@@ -5,7 +5,7 @@ extern crate alloc;
 use alloc::string::String;
 
 use ossm::{MechanicalConfig, MotionLimits, Ossm};
-use pattern_engine::{AnyPattern, Pattern, PatternEngine};
+use pattern_engine::{AnyPattern, PatternEngine};
 use sim_board::SimBoard;
 use sim_motor::SimMotor;
 use wasm_bindgen::prelude::*;
@@ -142,22 +142,20 @@ impl Simulator {
     }
 
     pub fn pattern_count(&self) -> usize {
-        AnyPattern::all_builtin().len()
+        AnyPattern::BUILTIN_PATTERNS.len()
     }
 
     pub fn pattern_name(&self, index: usize) -> String {
-        let patterns = AnyPattern::all_builtin();
-        patterns
+        AnyPattern::BUILTIN_PATTERNS
             .get(index)
-            .map(|p| String::from(p.name()))
+            .map(|p| String::from(p.name))
             .unwrap_or_default()
     }
 
     pub fn pattern_description(&self, index: usize) -> String {
-        let patterns = AnyPattern::all_builtin();
-        patterns
+        AnyPattern::BUILTIN_PATTERNS
             .get(index)
-            .map(|p| String::from(p.description()))
+            .map(|p| String::from(p.description))
             .unwrap_or_default()
     }
 }


### PR DESCRIPTION
## Problem

The pattern engine doesn't expose enough state and the current api is a bit of a mess.

<!-- What issue does this solve? Link any relevant issues. -->

## Solution

Expose the pattern engine state enum as an event and a pollable value. Also clean up patterns to allow you to resolve the Moving(pattern_id) with a specific pattern.

<!-- How does this PR solve the problem? -->

## Testing

Have tested on the web sim. Hardware tests will come with #63 - the ble remote.

<!-- If applicable, add screenshots or recordings. -->