### PR TITLE
ci: Add permission limitation to ci builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,8 @@ jobs:
   build-esp:
     name: Build ${{ matrix.firmware }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         firmware: [ossm-alt, waveshare]


### PR DESCRIPTION
## Problem

The ci permissions are dangerously broad

## Solution

<!-- How does this PR solve the problem? -->Limit them to just reading code

## Testing

The CI will pass before this can merge, the security issue should be resolved on merge.

<!-- If applicable, add screenshots or recordings. -->