### PR TITLE
fix(pattern-engine): Fix stroke being a percentage of depth

### DIFF
--- a/features/pattern-engine/src/input.rs
+++ b/features/pattern-engine/src/input.rs
@@ -5,8 +5,8 @@ use embassy_sync::watch::Watch;
 pub struct PatternInput {
     /// Maximum depth as a fraction of the machine range (0.0–1.0).
     pub depth: f64,
-    /// Stroke length as a fraction of the machine range (0.0–1.0).
-    /// Shallowest point = `depth - stroke`.
+    /// Stroke as a fraction of depth (0.0–1.0).
+    /// Shallowest point = `depth * (1.0 - stroke)`.
     pub stroke: f64,
     /// Velocity as a fraction of max velocity (0.0–1.0).
     pub velocity: f64,
@@ -17,7 +17,7 @@ pub struct PatternInput {
 impl PatternInput {
     pub const DEFAULT: Self = Self {
         depth: 0.5,
-        stroke: 0.4,
+        stroke: 0.5,
         velocity: 0.5,
         sensation: 0.0,
     };

--- a/features/pattern-engine/src/pattern.rs
+++ b/features/pattern-engine/src/pattern.rs
@@ -145,8 +145,8 @@ impl<'a, D: DelayNs> MotionBuilder<'a, D, NoPosition> {
 }
 
 fn compute_command(input: &PatternInput, fraction: f64, speed_factor: f64, torque: Option<f64>) -> MotionCommand {
-    let shallow = (input.depth - input.stroke).max(0.0);
-    let stroke = input.depth - shallow;
+    let stroke = input.depth * input.stroke.clamp(0.0, 1.0);
+    let shallow = input.depth - stroke;
     let position = shallow + fraction * stroke;
     let speed = input.velocity * speed_factor.clamp(0.0, 1.0);
     MotionCommand {


### PR DESCRIPTION
## Problem

After playing with the radr remote, I've realized the way we calculate stroke is incorrect. The stoke should be a percentage of the overall depth

## Solution

Change the pattern engine to reflect this

## Testing

- [x] Tested on ossm-alt