### PR TITLE
feat(telemetry): Adds telemetry over uart

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,7 +10,6 @@
     "UART",
     "xtensa"
   ],
-  "rust-analyzer.cfg.setTest": false,
   "rust-analyzer.check.allTargets": false,
   "rust-analyzer.check.workspace": false
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,6 +4,12 @@ version = 4
 
 [[package]]
 name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "allocator-api2"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c583acf993cf4245c4acb0a2cc2ab1f9cc097de73411bb6d3647ff6af2b1013d"
@@ -25,6 +31,12 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "az"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
 
 [[package]]
 name = "base64"
@@ -133,10 +145,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cobs"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea6d1b751c55bd9c0dda7d4ff752074e98f4765ae969664648bd193bb326d15"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
+name = "compact_str"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
 
 [[package]]
 name = "const-default"
@@ -308,6 +352,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -325,6 +378,12 @@ checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
 ]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "embassy-embedded-hal"
@@ -493,6 +552,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "embedded-graphics"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e8da660bb0c829b34a56a965490597f82a55e767b91f9543be80ce8ccb416fe"
+dependencies = [
+ "az",
+ "byteorder",
+ "embedded-graphics-core",
+ "float-cmp",
+ "micromath",
+]
+
+[[package]]
+name = "embedded-graphics-core"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95743bef3ff70fcba3930246c4e6872882bbea0dcc6da2ca860112e0cd4bd09f"
+dependencies = [
+ "az",
+ "byteorder",
+]
+
+[[package]]
+name = "embedded-graphics-unicodefonts"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a82ef1580d1bff3e89bd3e68069acb24910b66001aaab1738ce9de8d03d2ab1e"
+dependencies = [
+ "embedded-graphics",
+]
+
+[[package]]
 name = "embedded-hal"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -514,6 +605,16 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4c685bbef7fe13c3c6dd4da26841ed3980ef33e841cddfa15ce8a8fb3f1884"
 dependencies = [
+ "embedded-hal 1.0.0",
+]
+
+[[package]]
+name = "embedded-hal-bus"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513e0b3a8fb7d3013a8ae17a834283f170deaf7d0eeab0a7c1a36ad4dd356d22"
+dependencies = [
+ "critical-section",
  "embedded-hal 1.0.0",
 ]
 
@@ -595,7 +696,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "641e43d6a60244429117ef2fa7a47182120c7561336ea01f6fb08d634f46bae1"
 dependencies = [
- "allocator-api2",
+ "allocator-api2 0.3.1",
  "cfg-if",
  "document-features",
  "enumset",
@@ -767,7 +868,7 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "684c4de2f8907b73c9b891fbda65286a86d34fced4b856f36a7896c211f2f265"
 dependencies = [
- "allocator-api2",
+ "allocator-api2 0.3.1",
  "bt-hci",
  "cfg-if",
  "document-features",
@@ -829,7 +930,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "162ec711c8d06e79c67b75d01595539e86b0aac209643af98ca87a12250428b3"
 dependencies = [
- "allocator-api2",
+ "allocator-api2 0.3.1",
  "cfg-if",
  "document-features",
  "embassy-executor",
@@ -956,10 +1057,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "fugit"
@@ -1098,6 +1214,11 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2 0.2.21",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "heapless"
@@ -1179,6 +1300,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1219,6 +1349,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "kasuari"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fe90c1150662e858c7d5f945089b7517b0a80d8bf7ba4b1b5ffc984e7230a5b"
+dependencies = [
+ "hashbrown",
+ "thiserror",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1229,6 +1369,15 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "line-clipping"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f4de44e98ddbf09375cbf4d17714d18f39195f4f4894e8524501726fd9a8a4a"
+dependencies = [
+ "bitflags 2.11.0",
+]
 
 [[package]]
 name = "linked_list_allocator"
@@ -1258,6 +1407,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+dependencies = [
+ "hashbrown",
+]
+
+[[package]]
 name = "m57aim-motor"
 version = "0.1.0"
 dependencies = [
@@ -1273,6 +1431,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "micromath"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3c8dda44ff03a2f238717214da50f65d5a53b45cd213a7370424ffdb6fae815"
+
+[[package]]
+name = "mipidsi"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790ebd28bd67addbccf41b1c0c188c26bb9f5bdcd91d4d6da9bd558e20d97a1d"
+dependencies = [
+ "embedded-graphics-core",
+ "embedded-hal 1.0.0",
+ "heapless 0.8.0",
+]
+
+[[package]]
+name = "mousefood"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490c1ffdb94062231282102b75a38d47022faf28549c5f282aa5253354b62ff2"
+dependencies = [
+ "embedded-graphics",
+ "embedded-graphics-unicodefonts",
+ "ratatui-core",
+ "thiserror",
+]
+
+[[package]]
 name = "nb"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1286,6 +1473,12 @@ name = "nb"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d5439c4ad607c3c23abf66de8c8bf57ba8adcd1f129e699851a6e43935d339d"
+
+[[package]]
+name = "num-conv"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
 name = "num-derive"
@@ -1328,6 +1521,7 @@ name = "ossm"
 version = "0.1.0"
 dependencies = [
  "crc",
+ "embassy-futures",
  "embassy-sync 0.7.2",
  "embassy-time",
  "embedded-hal 1.0.0",
@@ -1337,6 +1531,7 @@ dependencies = [
  "log",
  "rmodbus",
  "rsruckig",
+ "telemetry",
 ]
 
 [[package]]
@@ -1364,6 +1559,7 @@ dependencies = [
  "portable-atomic",
  "rs485-board",
  "static_cell",
+ "telemetry",
 ]
 
 [[package]]
@@ -1471,6 +1667,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "proc-macro-crate"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1514,6 +1716,56 @@ name = "rand_core"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+
+[[package]]
+name = "ratatui"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1ce67fb8ba4446454d1c8dbaeda0557ff5e94d39d5e5ed7f10a65eb4c8266bc"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
+dependencies = [
+ "bitflags 2.11.0",
+ "compact_str",
+ "hashbrown",
+ "indoc",
+ "itertools",
+ "kasuari",
+ "lru",
+ "strum",
+ "thiserror",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.2",
+]
+
+[[package]]
+name = "ratatui-widgets"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
+dependencies = [
+ "bitflags 2.11.0",
+ "hashbrown",
+ "indoc",
+ "instability",
+ "itertools",
+ "line-clipping",
+ "ratatui-core",
+ "strum",
+ "time",
+ "unicode-segmentation",
+ "unicode-width 0.2.2",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -1644,33 +1896,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "seeed-xiao"
-version = "0.1.0"
-dependencies = [
- "ble-remote",
- "critical-section",
- "embassy-executor",
- "embassy-futures",
- "embassy-sync 0.7.2",
- "embassy-time",
- "esp-alloc",
- "esp-backtrace",
- "esp-bootloader-esp-idf",
- "esp-hal",
- "esp-println",
- "esp-radio",
- "esp-rtos",
- "log",
- "m57aim-motor",
- "ossm",
- "ossm-m5-remote",
- "pattern-engine",
- "portable-atomic",
- "rs485-board",
- "static_cell",
-]
-
-[[package]]
 name = "semihosting"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1750,6 +1975,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "sim-m5cores3"
+version = "0.1.0"
+dependencies = [
+ "critical-section",
+ "embassy-executor",
+ "embassy-futures",
+ "embassy-sync 0.7.2",
+ "embassy-time",
+ "esp-alloc",
+ "esp-backtrace",
+ "esp-bootloader-esp-idf",
+ "esp-hal",
+ "esp-println",
+ "esp-radio",
+ "esp-rtos",
+ "log",
+ "ossm",
+ "ossm-m5-remote",
+ "pattern-engine",
+ "portable-atomic",
+ "sim-m5cores3-board",
+ "sim-motor",
+ "static_cell",
+]
+
+[[package]]
+name = "sim-m5cores3-board"
+version = "0.1.0"
+dependencies = [
+ "embassy-time",
+ "embedded-graphics",
+ "embedded-hal 1.0.0",
+ "embedded-hal-bus",
+ "esp-hal",
+ "libm",
+ "log",
+ "mipidsi",
+ "mousefood",
+ "ratatui",
+ "sim-board",
+ "static_cell",
+]
+
+[[package]]
 name = "sim-motor"
 version = "0.1.0"
 
@@ -1804,6 +2073,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "static_cell"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1849,7 +2124,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
- "unicode-width",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -1872,6 +2147,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "telemetry"
+version = "0.1.0"
+dependencies = [
+ "cobs",
+ "crc",
+ "embassy-sync 0.7.2",
+ "embedded-io-async 0.7.0",
+ "log",
+ "ossm",
 ]
 
 [[package]]
@@ -1902,6 +2189,24 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "toml_datetime"
@@ -1991,10 +2296,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
+name = "unicode-truncate"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
+dependencies = [
+ "itertools",
+ "unicode-segmentation",
+ "unicode-width 0.2.2",
+]
+
+[[package]]
 name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unsafe-libyaml"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,12 +4,6 @@ version = 4
 
 [[package]]
 name = "allocator-api2"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
-
-[[package]]
-name = "allocator-api2"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c583acf993cf4245c4acb0a2cc2ab1f9cc097de73411bb6d3647ff6af2b1013d"
@@ -31,12 +25,6 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
-
-[[package]]
-name = "az"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
 
 [[package]]
 name = "base64"
@@ -145,15 +133,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
-name = "castaway"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -166,20 +145,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea6d1b751c55bd9c0dda7d4ff752074e98f4765ae969664648bd193bb326d15"
 dependencies = [
  "thiserror",
-]
-
-[[package]]
-name = "compact_str"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
-dependencies = [
- "castaway",
- "cfg-if",
- "itoa",
- "rustversion",
- "ryu",
- "static_assertions",
 ]
 
 [[package]]
@@ -352,15 +317,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "deranged"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
-dependencies = [
- "powerfmt",
-]
-
-[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -378,12 +334,6 @@ checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
 ]
-
-[[package]]
-name = "either"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "embassy-embedded-hal"
@@ -552,38 +502,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "embedded-graphics"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e8da660bb0c829b34a56a965490597f82a55e767b91f9543be80ce8ccb416fe"
-dependencies = [
- "az",
- "byteorder",
- "embedded-graphics-core",
- "float-cmp",
- "micromath",
-]
-
-[[package]]
-name = "embedded-graphics-core"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95743bef3ff70fcba3930246c4e6872882bbea0dcc6da2ca860112e0cd4bd09f"
-dependencies = [
- "az",
- "byteorder",
-]
-
-[[package]]
-name = "embedded-graphics-unicodefonts"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82ef1580d1bff3e89bd3e68069acb24910b66001aaab1738ce9de8d03d2ab1e"
-dependencies = [
- "embedded-graphics",
-]
-
-[[package]]
 name = "embedded-hal"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -605,16 +523,6 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4c685bbef7fe13c3c6dd4da26841ed3980ef33e841cddfa15ce8a8fb3f1884"
 dependencies = [
- "embedded-hal 1.0.0",
-]
-
-[[package]]
-name = "embedded-hal-bus"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "513e0b3a8fb7d3013a8ae17a834283f170deaf7d0eeab0a7c1a36ad4dd356d22"
-dependencies = [
- "critical-section",
  "embedded-hal 1.0.0",
 ]
 
@@ -696,7 +604,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "641e43d6a60244429117ef2fa7a47182120c7561336ea01f6fb08d634f46bae1"
 dependencies = [
- "allocator-api2 0.3.1",
+ "allocator-api2",
  "cfg-if",
  "document-features",
  "enumset",
@@ -868,7 +776,7 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "684c4de2f8907b73c9b891fbda65286a86d34fced4b856f36a7896c211f2f265"
 dependencies = [
- "allocator-api2 0.3.1",
+ "allocator-api2",
  "bt-hci",
  "cfg-if",
  "document-features",
@@ -930,7 +838,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "162ec711c8d06e79c67b75d01595539e86b0aac209643af98ca87a12250428b3"
 dependencies = [
- "allocator-api2 0.3.1",
+ "allocator-api2",
  "cfg-if",
  "document-features",
  "embassy-executor",
@@ -1057,25 +965,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "float-cmp"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foldhash"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "fugit"
@@ -1214,11 +1107,6 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-dependencies = [
- "allocator-api2 0.2.21",
- "equivalent",
- "foldhash",
-]
 
 [[package]]
 name = "heapless"
@@ -1300,15 +1188,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1349,16 +1228,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kasuari"
-version = "0.4.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fe90c1150662e858c7d5f945089b7517b0a80d8bf7ba4b1b5ffc984e7230a5b"
-dependencies = [
- "hashbrown",
- "thiserror",
-]
-
-[[package]]
 name = "libc"
 version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1369,15 +1238,6 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
-
-[[package]]
-name = "line-clipping"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4de44e98ddbf09375cbf4d17714d18f39195f4f4894e8524501726fd9a8a4a"
-dependencies = [
- "bitflags 2.11.0",
-]
 
 [[package]]
 name = "linked_list_allocator"
@@ -1407,15 +1267,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
-name = "lru"
-version = "0.16.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
-dependencies = [
- "hashbrown",
-]
-
-[[package]]
 name = "m57aim-motor"
 version = "0.1.0"
 dependencies = [
@@ -1431,35 +1282,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
-name = "micromath"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c8dda44ff03a2f238717214da50f65d5a53b45cd213a7370424ffdb6fae815"
-
-[[package]]
-name = "mipidsi"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "790ebd28bd67addbccf41b1c0c188c26bb9f5bdcd91d4d6da9bd558e20d97a1d"
-dependencies = [
- "embedded-graphics-core",
- "embedded-hal 1.0.0",
- "heapless 0.8.0",
-]
-
-[[package]]
-name = "mousefood"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490c1ffdb94062231282102b75a38d47022faf28549c5f282aa5253354b62ff2"
-dependencies = [
- "embedded-graphics",
- "embedded-graphics-unicodefonts",
- "ratatui-core",
- "thiserror",
-]
-
-[[package]]
 name = "nb"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1473,12 +1295,6 @@ name = "nb"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d5439c4ad607c3c23abf66de8c8bf57ba8adcd1f129e699851a6e43935d339d"
-
-[[package]]
-name = "num-conv"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
 name = "num-derive"
@@ -1667,12 +1483,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "powerfmt"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
-
-[[package]]
 name = "proc-macro-crate"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1716,56 +1526,6 @@ name = "rand_core"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
-
-[[package]]
-name = "ratatui"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1ce67fb8ba4446454d1c8dbaeda0557ff5e94d39d5e5ed7f10a65eb4c8266bc"
-dependencies = [
- "instability",
- "ratatui-core",
- "ratatui-widgets",
-]
-
-[[package]]
-name = "ratatui-core"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
-dependencies = [
- "bitflags 2.11.0",
- "compact_str",
- "hashbrown",
- "indoc",
- "itertools",
- "kasuari",
- "lru",
- "strum",
- "thiserror",
- "unicode-segmentation",
- "unicode-truncate",
- "unicode-width 0.2.2",
-]
-
-[[package]]
-name = "ratatui-widgets"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
-dependencies = [
- "bitflags 2.11.0",
- "hashbrown",
- "indoc",
- "instability",
- "itertools",
- "line-clipping",
- "ratatui-core",
- "strum",
- "time",
- "unicode-segmentation",
- "unicode-width 0.2.2",
-]
 
 [[package]]
 name = "redox_syscall"
@@ -1896,6 +1656,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "seeed-xiao"
+version = "0.1.0"
+dependencies = [
+ "ble-remote",
+ "critical-section",
+ "embassy-executor",
+ "embassy-futures",
+ "embassy-sync 0.7.2",
+ "embassy-time",
+ "esp-alloc",
+ "esp-backtrace",
+ "esp-bootloader-esp-idf",
+ "esp-hal",
+ "esp-println",
+ "esp-radio",
+ "esp-rtos",
+ "log",
+ "m57aim-motor",
+ "ossm",
+ "ossm-m5-remote",
+ "pattern-engine",
+ "portable-atomic",
+ "rs485-board",
+ "static_cell",
+]
+
+[[package]]
 name = "semihosting"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1975,50 +1762,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sim-m5cores3"
-version = "0.1.0"
-dependencies = [
- "critical-section",
- "embassy-executor",
- "embassy-futures",
- "embassy-sync 0.7.2",
- "embassy-time",
- "esp-alloc",
- "esp-backtrace",
- "esp-bootloader-esp-idf",
- "esp-hal",
- "esp-println",
- "esp-radio",
- "esp-rtos",
- "log",
- "ossm",
- "ossm-m5-remote",
- "pattern-engine",
- "portable-atomic",
- "sim-m5cores3-board",
- "sim-motor",
- "static_cell",
-]
-
-[[package]]
-name = "sim-m5cores3-board"
-version = "0.1.0"
-dependencies = [
- "embassy-time",
- "embedded-graphics",
- "embedded-hal 1.0.0",
- "embedded-hal-bus",
- "esp-hal",
- "libm",
- "log",
- "mipidsi",
- "mousefood",
- "ratatui",
- "sim-board",
- "static_cell",
-]
-
-[[package]]
 name = "sim-motor"
 version = "0.1.0"
 
@@ -2073,12 +1816,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
 name = "static_cell"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2124,7 +1861,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
- "unicode-width 0.1.14",
+ "unicode-width",
 ]
 
 [[package]]
@@ -2189,24 +1926,6 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
-
-[[package]]
-name = "time"
-version = "0.3.47"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
-dependencies = [
- "deranged",
- "num-conv",
- "powerfmt",
- "time-core",
-]
-
-[[package]]
-name = "time-core"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "toml_datetime"
@@ -2296,27 +2015,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
-name = "unicode-truncate"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
-dependencies = [
- "itertools",
- "unicode-segmentation",
- "unicode-width 0.2.2",
-]
-
-[[package]]
 name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
-
-[[package]]
-name = "unicode-width"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -2446,6 +2148,7 @@ dependencies = [
  "embassy-futures",
  "embassy-sync 0.7.2",
  "embassy-time",
+ "embedded-io-async 0.7.0",
  "esp-alloc",
  "esp-backtrace",
  "esp-bootloader-esp-idf",
@@ -2454,13 +2157,14 @@ dependencies = [
  "esp-radio",
  "esp-rtos",
  "log",
- "m57aim-motor",
  "ossm",
  "ossm-m5-remote",
  "pattern-engine",
  "portable-atomic",
- "rs485-board",
+ "sim-board",
+ "sim-motor",
  "static_cell",
+ "telemetry",
 ]
 
 [[package]]

--- a/apps/web-tools/pnpm-lock.yaml
+++ b/apps/web-tools/pnpm-lock.yaml
@@ -53,10 +53,10 @@ importers:
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: ^1.30.1
-        version: 1.30.1(vite@8.0.2(@types/node@24.12.0)(esbuild@0.27.3)(tsx@4.21.0))(workerd@1.20260317.1)(wrangler@4.77.0(@cloudflare/workers-types@4.20260317.1))
+        version: 1.30.2(vite@8.0.2(@types/node@24.12.0)(esbuild@0.27.3))(workerd@1.20260317.1)(wrangler@4.78.0(@cloudflare/workers-types@4.20260329.1))
       '@cloudflare/workers-types':
         specifier: ^4.20260317.1
-        version: 4.20260317.1
+        version: 4.20260329.1
       '@types/crypto-js':
         specifier: ^4.2.2
         version: 4.2.2
@@ -77,7 +77,7 @@ importers:
         version: 1.0.8
       '@vitejs/plugin-react':
         specifier: ^5.2.0
-        version: 5.2.0(vite@8.0.2(@types/node@24.12.0)(esbuild@0.27.3)(tsx@4.21.0))
+        version: 5.2.0(vite@8.0.2(@types/node@24.12.0)(esbuild@0.27.3))
       three-stdlib:
         specifier: ^2.36.1
         version: 2.36.1(three@0.183.2)
@@ -86,16 +86,16 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^8.0.2
-        version: 8.0.2(@types/node@24.12.0)(esbuild@0.27.3)(tsx@4.21.0)
+        version: 8.0.2(@types/node@24.12.0)(esbuild@0.27.3)
       vite-plugin-top-level-await:
         specifier: ^1.4.0
-        version: 1.6.0(rollup@4.59.0)(vite@8.0.2(@types/node@24.12.0)(esbuild@0.27.3)(tsx@4.21.0))
+        version: 1.6.0(rollup@4.59.0)(vite@8.0.2(@types/node@24.12.0)(esbuild@0.27.3))
       vite-plugin-wasm:
         specifier: ^3.6.0
-        version: 3.6.0(vite@8.0.2(@types/node@24.12.0)(esbuild@0.27.3)(tsx@4.21.0))
+        version: 3.6.0(vite@8.0.2(@types/node@24.12.0)(esbuild@0.27.3))
       wrangler:
         specifier: ^4.77.0
-        version: 4.77.0(@cloudflare/workers-types@4.20260317.1)
+        version: 4.78.0(@cloudflare/workers-types@4.20260329.1)
 
 packages:
 
@@ -199,11 +199,11 @@ packages:
       workerd:
         optional: true
 
-  '@cloudflare/vite-plugin@1.30.1':
-    resolution: {integrity: sha512-gDWf2VJNRDp3ktWsTapx3gzffVfE2mkLiziiQOZGPgipvVBgWsCHO4UGqCDoLkXtB2gw4zgbGUKKqxBOn7WTSg==}
+  '@cloudflare/vite-plugin@1.30.2':
+    resolution: {integrity: sha512-1TG/GyYxMAVhRtbKs9dPCsJY+c4qaPk+NKiLywKLV/BuvgMTBGhrmIvkC9NQSaw9sa5fPOYmv9me68AIs5kXJQ==}
     peerDependencies:
       vite: ^6.1.0 || ^7.0.0 || ^8.0.0
-      wrangler: ^4.77.0
+      wrangler: ^4.78.0
 
   '@cloudflare/workerd-darwin-64@1.20260317.1':
     resolution: {integrity: sha512-8hjh3sPMwY8M/zedq3/sXoA2Q4BedlGufn3KOOleIG+5a4ReQKLlUah140D7J6zlKmYZAFMJ4tWC7hCuI/s79g==}
@@ -235,8 +235,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@cloudflare/workers-types@4.20260317.1':
-    resolution: {integrity: sha512-+G4eVwyCpm8Au1ex8vQBCuA9wnwqetz4tPNRoB/53qvktERWBRMQnrtvC1k584yRE3emMThtuY0gWshvSJ++PQ==}
+  '@cloudflare/workers-types@4.20260329.1':
+    resolution: {integrity: sha512-LxBHrYYI/AZ6OCbUzRqRgg6Rt1qev2KxN2NNd3saye41AO2g52cYvHV+ohts5oPnrIUD7YRjbgN/J3NU7e7m5A==}
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -1975,9 +1975,6 @@ packages:
     resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
     engines: {node: '>=6'}
 
-  get-tsconfig@4.13.7:
-    resolution: {integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==}
-
   glsl-noise@0.0.0:
     resolution: {integrity: sha512-b/ZCF6amfAUb7dJM/MxRs7AetQEahYzJ8PtgfrmEdtw6uyGOr+ZSGtgjFm6mfsBkxJ4d2W7kg+Nlqzqvn3Bc0w==}
 
@@ -2279,8 +2276,8 @@ packages:
   micromark@4.0.2:
     resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
-  miniflare@4.20260317.2:
-    resolution: {integrity: sha512-qNL+yWAFMX6fr0pWU6Lx1vNpPobpnDSF1V8eunIckWvoIQl8y1oBjL2RJFEGY3un+l3f9gwW9dirDPP26usYJQ==}
+  miniflare@4.20260317.3:
+    resolution: {integrity: sha512-tK78D3X4q30/SXqVwMhWrUfH+ffRou9dJLC+jkhNy5zh1I7i7T4JH6xihOvYxdCSBavJ5fQXaaxDJz6orh09BA==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -2428,9 +2425,6 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
-  resolve-pkg-maps@1.0.0:
-    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
-
   rolldown@1.0.0-rc.11:
     resolution: {integrity: sha512-NRjoKMusSjfRbSYiH3VSumlkgFe7kYAa3pzVOsVYVFY3zb5d7nS+a3KGQ7hJKXuYWbzJKPVQ9Wxq2UvyK+ENpw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2540,11 +2534,6 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
-
-  tsx@4.21.0:
-    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
-    engines: {node: '>=18.0.0'}
-    hasBin: true
 
   tunnel-rat@0.1.2:
     resolution: {integrity: sha512-lR5VHmkPhzdhrM092lI2nACsLO4QubF0/yoOhzX7c+wIpbN1GjHNzCc91QlpxBi+cnx8vVJ+Ur6vL5cEoQPFpQ==}
@@ -2696,8 +2685,8 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
-  wrangler@4.77.0:
-    resolution: {integrity: sha512-E2Gm69+K++BFd3QvoWjC290RPQj1vDOUotA++sNHmtKPb7EP6C8Qv+1D5Ii73tfZtyNgakpqHlh8lBBbVWTKAQ==}
+  wrangler@4.78.0:
+    resolution: {integrity: sha512-He/vUhk4ih0D0eFmtNnlbT6Od8j+BEokaSR+oYjbVsH0SWIrIch+eHqfLRSBjBQaOoh6HCNxcafcIkBm2u0Hag==}
     engines: {node: '>=20.3.0'}
     hasBin: true
     peerDependencies:
@@ -2887,13 +2876,13 @@ snapshots:
     optionalDependencies:
       workerd: 1.20260317.1
 
-  '@cloudflare/vite-plugin@1.30.1(vite@8.0.2(@types/node@24.12.0)(esbuild@0.27.3)(tsx@4.21.0))(workerd@1.20260317.1)(wrangler@4.77.0(@cloudflare/workers-types@4.20260317.1))':
+  '@cloudflare/vite-plugin@1.30.2(vite@8.0.2(@types/node@24.12.0)(esbuild@0.27.3))(workerd@1.20260317.1)(wrangler@4.78.0(@cloudflare/workers-types@4.20260329.1))':
     dependencies:
       '@cloudflare/unenv-preset': 2.16.0(unenv@2.0.0-rc.24)(workerd@1.20260317.1)
-      miniflare: 4.20260317.2
+      miniflare: 4.20260317.3
       unenv: 2.0.0-rc.24
-      vite: 8.0.2(@types/node@24.12.0)(esbuild@0.27.3)(tsx@4.21.0)
-      wrangler: 4.77.0(@cloudflare/workers-types@4.20260317.1)
+      vite: 8.0.2(@types/node@24.12.0)(esbuild@0.27.3)
+      wrangler: 4.78.0(@cloudflare/workers-types@4.20260329.1)
       ws: 8.18.0
     transitivePeerDependencies:
       - bufferutil
@@ -2915,7 +2904,7 @@ snapshots:
   '@cloudflare/workerd-windows-64@1.20260317.1':
     optional: true
 
-  '@cloudflare/workers-types@4.20260317.1': {}
+  '@cloudflare/workers-types@4.20260329.1': {}
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
@@ -4287,7 +4276,7 @@ snapshots:
       '@use-gesture/core': 10.3.1
       react: 19.2.4
 
-  '@vitejs/plugin-react@5.2.0(vite@8.0.2(@types/node@24.12.0)(esbuild@0.27.3)(tsx@4.21.0))':
+  '@vitejs/plugin-react@5.2.0(vite@8.0.2(@types/node@24.12.0)(esbuild@0.27.3))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -4295,7 +4284,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.3
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
-      vite: 8.0.2(@types/node@24.12.0)(esbuild@0.27.3)(tsx@4.21.0)
+      vite: 8.0.2(@types/node@24.12.0)(esbuild@0.27.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -4455,11 +4444,6 @@ snapshots:
   gensync@1.0.0-beta.2: {}
 
   get-nonce@1.0.1: {}
-
-  get-tsconfig@4.13.7:
-    dependencies:
-      resolve-pkg-maps: 1.0.0
-    optional: true
 
   glsl-noise@0.0.0: {}
 
@@ -4947,7 +4931,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  miniflare@4.20260317.2:
+  miniflare@4.20260317.3:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       sharp: 0.34.5
@@ -5169,9 +5153,6 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
-  resolve-pkg-maps@1.0.0:
-    optional: true
-
   rolldown@1.0.0-rc.11:
     dependencies:
       '@oxc-project/types': 0.122.0
@@ -5341,14 +5322,6 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsx@4.21.0:
-    dependencies:
-      esbuild: 0.27.3
-      get-tsconfig: 4.13.7
-    optionalDependencies:
-      fsevents: 2.3.3
-    optional: true
-
   tunnel-rat@0.1.2(@types/react@19.2.14)(react@19.2.4):
     dependencies:
       zustand: 4.5.7(@types/react@19.2.14)(react@19.2.4)
@@ -5439,22 +5412,22 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-plugin-top-level-await@1.6.0(rollup@4.59.0)(vite@8.0.2(@types/node@24.12.0)(esbuild@0.27.3)(tsx@4.21.0)):
+  vite-plugin-top-level-await@1.6.0(rollup@4.59.0)(vite@8.0.2(@types/node@24.12.0)(esbuild@0.27.3)):
     dependencies:
       '@rollup/plugin-virtual': 3.0.2(rollup@4.59.0)
       '@swc/core': 1.15.18
       '@swc/wasm': 1.15.18
       uuid: 10.0.0
-      vite: 8.0.2(@types/node@24.12.0)(esbuild@0.27.3)(tsx@4.21.0)
+      vite: 8.0.2(@types/node@24.12.0)(esbuild@0.27.3)
     transitivePeerDependencies:
       - '@swc/helpers'
       - rollup
 
-  vite-plugin-wasm@3.6.0(vite@8.0.2(@types/node@24.12.0)(esbuild@0.27.3)(tsx@4.21.0)):
+  vite-plugin-wasm@3.6.0(vite@8.0.2(@types/node@24.12.0)(esbuild@0.27.3)):
     dependencies:
-      vite: 8.0.2(@types/node@24.12.0)(esbuild@0.27.3)(tsx@4.21.0)
+      vite: 8.0.2(@types/node@24.12.0)(esbuild@0.27.3)
 
-  vite@8.0.2(@types/node@24.12.0)(esbuild@0.27.3)(tsx@4.21.0):
+  vite@8.0.2(@types/node@24.12.0)(esbuild@0.27.3):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.3
@@ -5465,7 +5438,6 @@ snapshots:
       '@types/node': 24.12.0
       esbuild: 0.27.3
       fsevents: 2.3.3
-      tsx: 4.21.0
 
   webgl-constants@1.1.1: {}
 
@@ -5483,18 +5455,18 @@ snapshots:
       '@cloudflare/workerd-linux-arm64': 1.20260317.1
       '@cloudflare/workerd-windows-64': 1.20260317.1
 
-  wrangler@4.77.0(@cloudflare/workers-types@4.20260317.1):
+  wrangler@4.78.0(@cloudflare/workers-types@4.20260329.1):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.2
       '@cloudflare/unenv-preset': 2.16.0(unenv@2.0.0-rc.24)(workerd@1.20260317.1)
       blake3-wasm: 2.1.5
       esbuild: 0.27.3
-      miniflare: 4.20260317.2
+      miniflare: 4.20260317.3
       path-to-regexp: 6.3.0
       unenv: 2.0.0-rc.24
       workerd: 1.20260317.1
     optionalDependencies:
-      '@cloudflare/workers-types': 4.20260317.1
+      '@cloudflare/workers-types': 4.20260329.1
       fsevents: 2.3.3
     transitivePeerDependencies:
       - bufferutil

--- a/apps/web-tools/src/App.tsx
+++ b/apps/web-tools/src/App.tsx
@@ -29,6 +29,7 @@ import {
   PauseIcon,
   StopIcon,
 } from "@radix-ui/react-icons";
+import { Link } from "react-router";
 import Scene from "./Scene";
 import type { SceneHandle } from "./Scene";
 
@@ -148,7 +149,7 @@ export default function App() {
           >
             <Scene
               ref={sceneRef}
-              simulator={simulator}
+              getPosition={() => simulator.get_position()}
               zoom={isMobile ? 900 : 1500}
             />
           </Suspense>
@@ -321,6 +322,10 @@ export default function App() {
                   style={{ width: "100%" }}
                 >
                   <ResetIcon /> Reset View
+                </Button>
+
+                <Button variant="outline" asChild style={{ width: "100%" }}>
+                  <Link to="/device">Device Mode</Link>
                 </Button>
               </Flex>
             </ScrollArea>

--- a/apps/web-tools/src/Layout.tsx
+++ b/apps/web-tools/src/Layout.tsx
@@ -42,6 +42,13 @@ export default function Layout() {
                   </TabNav.Link>
                 )}
               </NavLink>
+              <NavLink to="/debugging">
+                {({ isActive }) => (
+                  <TabNav.Link asChild active={isActive}>
+                    <span>Debugging</span>
+                  </TabNav.Link>
+                )}
+              </NavLink>
             </TabNav.Root>
           </Flex>
           <Flex align="center" gap="2">

--- a/apps/web-tools/src/Scene.tsx
+++ b/apps/web-tools/src/Scene.tsx
@@ -23,7 +23,6 @@ import {
 } from "three";
 import type { Object3D } from "three";
 import { mergeGeometries } from "three/examples/jsm/utils/BufferGeometryUtils.js";
-import type { Simulator } from "sim-wasm";
 import { useAppearance } from "./hooks/useAppearance";
 
 const MODEL_URL = "/models/ossm-alt.gltf";
@@ -53,10 +52,10 @@ function collectGeometries(root: Object3D): BufferGeometry | null {
 }
 
 function Model({
-  simulator,
+  getPosition,
   onOrbitTarget,
 }: {
-  simulator: Simulator;
+  getPosition: () => number;
   onOrbitTarget?: (center: Vector3) => void;
 }) {
   const { scene } = useGLTF(MODEL_URL);
@@ -82,7 +81,7 @@ function Model({
 
   useFrame(() => {
     if (railRef.current) {
-      const pos = simulator.get_position();
+      const pos = getPosition();
       railRef.current.position.z = -(1 - pos) * RAIL_TRAVEL;
     }
   });
@@ -106,11 +105,11 @@ const RESET_LERP_SPEED = 0.08;
 const RESET_SNAP_THRESHOLD = 0.0001;
 
 function SceneContent({
-  simulator,
+  getPosition,
   handle,
   zoom,
 }: {
-  simulator: Simulator;
+  getPosition: () => number;
   handle: React.Ref<SceneHandle>;
   zoom: number;
 }) {
@@ -166,7 +165,7 @@ function SceneContent({
       <directionalLight position={[1, 2, 3]} intensity={isDark ? 0.8 : 1.5} />
       <directionalLight position={[-1, 1, -1]} intensity={isDark ? 0.3 : 0.5} />
       <Environment preset="studio" environmentIntensity={isDark ? 0.4 : 1} />
-      <Model simulator={simulator} onOrbitTarget={onOrbitTarget} />
+      <Model getPosition={getPosition} onOrbitTarget={onOrbitTarget} />
       <OrthographicCamera
         makeDefault
         position={INITIAL_CAMERA}
@@ -180,14 +179,14 @@ function SceneContent({
 }
 
 const Scene = memo(
-  forwardRef<SceneHandle, { simulator: Simulator; zoom?: number }>(
-    function Scene({ simulator, zoom = 1500 }, ref) {
+  forwardRef<SceneHandle, { getPosition: () => number; zoom?: number }>(
+    function Scene({ getPosition, zoom = 1500 }, ref) {
       return (
         <Canvas
           gl={{ toneMapping: ACESFilmicToneMapping, toneMappingExposure: 1.2 }}
           style={{ width: "100%", height: "100%" }}
         >
-          <SceneContent simulator={simulator} handle={ref} zoom={zoom} />
+          <SceneContent getPosition={getPosition} handle={ref} zoom={zoom} />
         </Canvas>
       );
     },

--- a/apps/web-tools/src/lib/device-connection.ts
+++ b/apps/web-tools/src/lib/device-connection.ts
@@ -1,0 +1,207 @@
+import {
+  TelemetryDecoder,
+  MotionPhase,
+  type CoreTelemetryPayload,
+} from "./telemetry";
+
+export type ConnectionStatus =
+  | "disconnected"
+  | "connecting"
+  | "connected"
+  | "reconnecting";
+
+export interface DeviceConnectionEvents {
+  telemetry: (payload: CoreTelemetryPayload) => void;
+  log: (text: string) => void;
+  status: (status: ConnectionStatus) => void;
+}
+
+type Listener<K extends keyof DeviceConnectionEvents> = DeviceConnectionEvents[K];
+
+/**
+ * Manages a Web Serial connection to an OSSM device.
+ * Reads the byte stream, splits COBS telemetry frames from ASCII log lines,
+ * and exposes the latest telemetry state for polling.
+ */
+export class DeviceConnection {
+  private port: SerialPort | null = null;
+  private reader: ReadableStreamDefaultReader<Uint8Array> | null = null;
+  private running = false;
+  private decoder = new TelemetryDecoder();
+  private listeners = new Map<string, Set<Function>>();
+
+  private _status: ConnectionStatus = "disconnected";
+  private _latestTelemetry: CoreTelemetryPayload = {
+    position: 0,
+    velocity: 0,
+    torque: 0,
+    phase: MotionPhase.Disabled,
+    sequence: 0,
+  };
+
+  get status() {
+    return this._status;
+  }
+
+  get position() {
+    return this._latestTelemetry.position;
+  }
+
+  get phase() {
+    return this._latestTelemetry.phase;
+  }
+
+  get latestTelemetry() {
+    return this._latestTelemetry;
+  }
+
+  on<K extends keyof DeviceConnectionEvents>(
+    event: K,
+    listener: Listener<K>,
+  ) {
+    if (!this.listeners.has(event)) this.listeners.set(event, new Set());
+    this.listeners.get(event)!.add(listener);
+  }
+
+  off<K extends keyof DeviceConnectionEvents>(
+    event: K,
+    listener: Listener<K>,
+  ) {
+    this.listeners.get(event)?.delete(listener);
+  }
+
+  private emit<K extends keyof DeviceConnectionEvents>(
+    event: K,
+    ...args: Parameters<DeviceConnectionEvents[K]>
+  ) {
+    const set = this.listeners.get(event);
+    if (!set) return;
+    for (const fn of set) (fn as Function)(...args);
+  }
+
+  private setStatus(status: ConnectionStatus) {
+    this._status = status;
+    this.emit("status", status);
+  }
+
+  /**
+   * Prompt the user to select a serial port and begin reading telemetry.
+   * If a port was previously granted, `getPorts()` will return it without
+   * showing the dialog again.
+   */
+  async connect(baudRate = 115200) {
+    if (this._status === "connected" || this._status === "connecting") return;
+
+    this.setStatus("connecting");
+
+    try {
+      // Try previously-granted ports first, fall back to picker
+      const ports = await navigator.serial.getPorts();
+      this.port = ports[0] ?? (await navigator.serial.requestPort());
+
+      await this.port.open({ baudRate });
+      this.running = true;
+      this.setStatus("connected");
+
+      this.port.addEventListener("disconnect", this.onDisconnect);
+      this.readLoop();
+    } catch (err) {
+      this.setStatus("disconnected");
+      throw err;
+    }
+  }
+
+  async disconnect() {
+    this.running = false;
+    this.port?.removeEventListener("disconnect", this.onDisconnect);
+
+    try {
+      await this.reader?.cancel();
+    } catch {
+      // reader may already be released
+    }
+    this.reader = null;
+
+    try {
+      await this.port?.close();
+    } catch {
+      // port may already be closed
+    }
+    this.port = null;
+
+    this.setStatus("disconnected");
+  }
+
+  private onDisconnect = () => {
+    this.running = false;
+    this.reader = null;
+    this.port = null;
+    this.setStatus("reconnecting");
+    this.attemptReconnect();
+  };
+
+  private async attemptReconnect() {
+    const maxAttempts = 30;
+    const intervalMs = 1000;
+
+    for (let i = 0; i < maxAttempts; i++) {
+      await sleep(intervalMs);
+      if (this._status !== "reconnecting") return;
+
+      try {
+        const ports = await navigator.serial.getPorts();
+        if (ports.length === 0) continue;
+
+        this.port = ports[0];
+        await this.port.open({ baudRate: 115200 });
+        this.running = true;
+        this.decoder = new TelemetryDecoder();
+        this.setStatus("connected");
+
+        this.port.addEventListener("disconnect", this.onDisconnect);
+        this.readLoop();
+        return;
+      } catch {
+        // port not ready yet, keep trying
+      }
+    }
+
+    this.setStatus("disconnected");
+  }
+
+  private async readLoop() {
+    if (!this.port?.readable) return;
+
+    try {
+      this.reader = this.port.readable.getReader();
+
+      while (this.running) {
+        const { value, done } = await this.reader.read();
+        if (done || !value) break;
+
+        const frames = this.decoder.push(value);
+        for (const frame of frames) {
+          if (frame.type === "telemetry") {
+            this._latestTelemetry = frame.payload;
+            this.emit("telemetry", frame.payload);
+          } else {
+            this.emit("log", frame.text);
+          }
+        }
+      }
+    } catch {
+      // read error — likely disconnect, handled by onDisconnect
+    } finally {
+      try {
+        this.reader?.releaseLock();
+      } catch {
+        // already released
+      }
+      this.reader = null;
+    }
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/apps/web-tools/src/lib/telemetry.ts
+++ b/apps/web-tools/src/lib/telemetry.ts
@@ -1,0 +1,181 @@
+/**
+ * Telemetry protocol decoder matching the firmware's COBS + CRC8 wire format.
+ *
+ * Wire format: [COBS-encoded frame][0x00 delimiter]
+ * Decoded frame: [frame_type: u8][payload: N bytes][crc8: u8]
+ *
+ * CoreTelemetry payload (15 bytes, little-endian):
+ *   [0..4]   f32  position  (0.0–1.0)
+ *   [4..8]   f32  velocity  (0.0–1.0)
+ *   [8..12]  f32  torque    (0.0–1.0)
+ *   [12]     u8   phase     (MotionPhase enum)
+ *   [13..15] u16  sequence  (wrapping counter)
+ */
+
+export const enum FrameType {
+  CoreTelemetry = 0x01,
+}
+
+export const enum MotionPhase {
+  Disabled = 0,
+  Enabled = 1,
+  Ready = 2,
+  Moving = 3,
+  Stopping = 4,
+  Paused = 5,
+}
+
+export interface CoreTelemetryPayload {
+  position: number;
+  velocity: number;
+  torque: number;
+  phase: MotionPhase;
+  sequence: number;
+}
+
+// CRC-8-SMBUS lookup table (polynomial 0x07)
+const CRC8_TABLE = new Uint8Array(256);
+{
+  for (let i = 0; i < 256; i++) {
+    let crc = i;
+    for (let bit = 0; bit < 8; bit++) {
+      crc = crc & 0x80 ? (crc << 1) ^ 0x07 : crc << 1;
+    }
+    CRC8_TABLE[i] = crc & 0xff;
+  }
+}
+
+function crc8(data: Uint8Array, start: number, length: number): number {
+  let crc = 0x00;
+  for (let i = start; i < start + length; i++) {
+    crc = CRC8_TABLE[(crc ^ data[i]) & 0xff];
+  }
+  return crc;
+}
+
+/** COBS-decode in place. Returns the decoded length, or -1 on error. */
+function cobsDecode(encoded: Uint8Array, length: number): number {
+  if (length === 0) return 0;
+
+  let readIdx = 0;
+  let writeIdx = 0;
+
+  while (readIdx < length) {
+    const code = encoded[readIdx++];
+    if (code === 0) return -1; // unexpected zero in COBS data
+
+    const dataLen = code - 1;
+    if (readIdx + dataLen > length) return -1;
+
+    for (let i = 0; i < dataLen; i++) {
+      encoded[writeIdx++] = encoded[readIdx++];
+    }
+
+    // If code < 0xFF, there's an implicit zero (unless we've consumed everything)
+    if (code < 0xff && readIdx < length) {
+      encoded[writeIdx++] = 0x00;
+    }
+  }
+
+  return writeIdx;
+}
+
+function parseCoreTelemetry(payload: Uint8Array): CoreTelemetryPayload {
+  const view = new DataView(
+    payload.buffer,
+    payload.byteOffset,
+    payload.byteLength,
+  );
+  return {
+    position: view.getFloat32(0, true),
+    velocity: view.getFloat32(4, true),
+    torque: view.getFloat32(8, true),
+    phase: payload[12] as MotionPhase,
+    sequence: view.getUint16(13, true),
+  };
+}
+
+export type TelemetryFrame =
+  | { type: "telemetry"; payload: CoreTelemetryPayload }
+  | { type: "log"; text: string };
+
+/**
+ * Accumulates raw bytes from the wire and yields decoded telemetry frames
+ * or ASCII log lines. Splits on 0x00 delimiter: binary packets are decoded
+ * as COBS telemetry frames, printable ASCII segments are passed through as logs.
+ */
+export class TelemetryDecoder {
+  private buffer = new Uint8Array(256);
+  private pos = 0;
+
+  push(chunk: Uint8Array): TelemetryFrame[] {
+    const frames: TelemetryFrame[] = [];
+
+    for (let i = 0; i < chunk.length; i++) {
+      const byte = chunk[i];
+
+      if (byte === 0x00) {
+        if (this.pos > 0) {
+          const frame = this.processPacket();
+          if (frame) frames.push(frame);
+          this.pos = 0;
+        }
+        continue;
+      }
+
+      // Grow buffer if needed
+      if (this.pos >= this.buffer.length) {
+        const next = new Uint8Array(this.buffer.length * 2);
+        next.set(this.buffer);
+        this.buffer = next;
+      }
+
+      this.buffer[this.pos++] = byte;
+    }
+
+    return frames;
+  }
+
+  private processPacket(): TelemetryFrame | null {
+    const raw = this.buffer.subarray(0, this.pos);
+
+    // If all bytes are printable ASCII (0x0A, 0x0D, 0x20-0x7E), treat as log line
+    if (this.isAscii(raw)) {
+      const text = new TextDecoder().decode(raw).trim();
+      if (text.length > 0) {
+        return { type: "log", text };
+      }
+      return null;
+    }
+
+    // Otherwise attempt COBS + CRC decode
+    const work = new Uint8Array(this.pos);
+    work.set(raw);
+
+    const decoded = cobsDecode(work, this.pos);
+    if (decoded < 2) return null; // need at least frame_type + crc
+
+    const frameType = work[0];
+    const payloadLen = decoded - 2; // exclude type and crc bytes
+    const receivedCrc = work[decoded - 1];
+    const computedCrc = crc8(work, 0, decoded - 1);
+
+    if (receivedCrc !== computedCrc) return null;
+
+    if (frameType === FrameType.CoreTelemetry && payloadLen === 15) {
+      const payload = parseCoreTelemetry(work.subarray(1, 16));
+      return { type: "telemetry", payload };
+    }
+
+    return null;
+  }
+
+  private isAscii(data: Uint8Array): boolean {
+    for (let i = 0; i < data.length; i++) {
+      const b = data[i];
+      if (b === 0x0a || b === 0x0d || (b >= 0x20 && b <= 0x7e)) continue;
+      return false;
+    }
+    return true;
+  }
+}

--- a/apps/web-tools/src/main.tsx
+++ b/apps/web-tools/src/main.tsx
@@ -7,6 +7,7 @@ import { SimulatorProvider } from "./SimulatorProvider";
 import Layout from "./Layout";
 import FlasherPage from "./pages/FlasherPage";
 import SimulatorPage from "./pages/SimulatorPage";
+import DebuggingPage from "./pages/DebuggingPage";
 
 createRoot(document.getElementById("root")!).render(
   <BrowserRouter>
@@ -23,6 +24,7 @@ createRoot(document.getElementById("root")!).render(
               <Route path="pr/:pr" element={null} />
             </Route>
             <Route path="flasher" element={<FlasherPage />} />
+            <Route path="debugging" element={<DebuggingPage />} />
           </Route>
         </Routes>
       </SimulatorProvider>

--- a/apps/web-tools/src/pages/DebuggingPage.tsx
+++ b/apps/web-tools/src/pages/DebuggingPage.tsx
@@ -1,0 +1,259 @@
+import {
+  Suspense,
+  useRef,
+  useEffect,
+  useCallback,
+  useSyncExternalStore,
+} from "react";
+import {
+  Box,
+  Card,
+  Flex,
+  Heading,
+  Text,
+  Button,
+  Spinner,
+  Separator,
+  ScrollArea,
+  Badge,
+} from "@radix-ui/themes";
+import {
+  ResetIcon,
+  Link2Icon,
+  LinkBreak2Icon,
+} from "@radix-ui/react-icons";
+import Scene from "../Scene";
+import type { SceneHandle } from "../Scene";
+import { useIsMobile } from "../hooks/useIsMobile";
+import {
+  DeviceConnection,
+  type ConnectionStatus,
+} from "../lib/device-connection";
+import { MotionPhase, type CoreTelemetryPayload } from "../lib/telemetry";
+
+const device = new DeviceConnection();
+
+function useConnectionStatus(): ConnectionStatus {
+  return useSyncExternalStore(
+    (onChange) => {
+      device.on("status", onChange);
+      return () => device.off("status", onChange);
+    },
+    () => device.status,
+  );
+}
+
+function useTelemetry(): CoreTelemetryPayload {
+  const ref = useRef(device.latestTelemetry);
+
+  return useSyncExternalStore(
+    (onChange) => {
+      const handler = (payload: CoreTelemetryPayload) => {
+        ref.current = payload;
+        onChange();
+      };
+      device.on("telemetry", handler);
+      return () => device.off("telemetry", handler);
+    },
+    () => ref.current,
+  );
+}
+
+const STATUS_LABEL: Record<ConnectionStatus, string> = {
+  disconnected: "Disconnected",
+  connecting: "Connecting…",
+  connected: "Connected",
+  reconnecting: "Device flashing…",
+};
+
+const STATUS_COLOR: Record<ConnectionStatus, "red" | "yellow" | "green" | "orange"> = {
+  disconnected: "red",
+  connecting: "yellow",
+  connected: "green",
+  reconnecting: "orange",
+};
+
+const PHASE_LABEL: Record<MotionPhase, string> = {
+  [MotionPhase.Disabled]: "Disabled",
+  [MotionPhase.Enabled]: "Enabled",
+  [MotionPhase.Ready]: "Ready",
+  [MotionPhase.Moving]: "Moving",
+  [MotionPhase.Stopping]: "Stopping",
+  [MotionPhase.Paused]: "Paused",
+};
+
+export default function DebuggingPage() {
+  const sceneRef = useRef<SceneHandle>(null);
+  const isMobile = useIsMobile();
+  const status = useConnectionStatus();
+  const telemetry = useTelemetry();
+
+  useEffect(() => {
+    return () => {
+      device.disconnect();
+    };
+  }, []);
+
+  const handleConnect = useCallback(async () => {
+    try {
+      await device.connect();
+    } catch (err) {
+      console.error("Failed to connect:", err);
+    }
+  }, []);
+
+  const handleDisconnect = useCallback(async () => {
+    await device.disconnect();
+  }, []);
+
+  const getPosition = useCallback(() => device.position, []);
+
+  const isConnected = status === "connected";
+  const isDisconnected = status === "disconnected";
+
+  return (
+    <Flex direction={isMobile ? "column" : "row"} style={{ flex: 1, minHeight: 0 }}>
+      <Box
+        style={{
+          flex: isMobile ? undefined : 1,
+          height: isMobile ? "30vh" : undefined,
+          minHeight: 0,
+          position: "relative",
+        }}
+      >
+        <Suspense
+          fallback={
+            <Flex align="center" justify="center" height="100%" gap="3">
+              <Spinner size="3" />
+              <Text size="2">Loading model…</Text>
+            </Flex>
+          }
+        >
+          <Scene
+            ref={sceneRef}
+            getPosition={getPosition}
+            zoom={isMobile ? 900 : 1500}
+          />
+        </Suspense>
+      </Box>
+
+      <Box
+        style={{
+          width: isMobile ? undefined : "360px",
+          flexShrink: 0,
+        }}
+        p="3"
+      >
+        <Card
+          size="2"
+          style={{
+            height: "100%",
+            display: "flex",
+            flexDirection: "column",
+          }}
+        >
+          <Flex justify="between" align="center" mb="3">
+            <Heading size="5">Device</Heading>
+          </Flex>
+
+          <Separator size="4" mb="3" />
+
+          <ScrollArea style={{ flex: 1 }} scrollbars="vertical">
+            <Flex direction="column" gap="4" pr="1">
+              <Flex align="center" gap="2">
+                <Badge color={STATUS_COLOR[status]} variant="soft" size="2">
+                  {STATUS_LABEL[status]}
+                </Badge>
+              </Flex>
+
+              {isDisconnected && (
+                <Button onClick={handleConnect} variant="solid" size="3">
+                  <Link2Icon /> Connect
+                </Button>
+              )}
+
+              {isConnected && (
+                <Button
+                  onClick={handleDisconnect}
+                  variant="outline"
+                  size="3"
+                >
+                  <LinkBreak2Icon /> Disconnect
+                </Button>
+              )}
+
+              {status === "reconnecting" && (
+                <Flex align="center" gap="2">
+                  <Spinner size="2" />
+                  <Text size="2" color="gray">
+                    Waiting for device to reappear…
+                  </Text>
+                </Flex>
+              )}
+
+              {(isConnected || status === "reconnecting") && (
+                <>
+                  <Separator size="4" />
+                  <TelemetryDisplay telemetry={telemetry} />
+                </>
+              )}
+
+              <Separator size="4" />
+
+              <Button
+                variant="outline"
+                onClick={() => sceneRef.current?.resetView()}
+                style={{ width: "100%" }}
+              >
+                <ResetIcon /> Reset View
+              </Button>
+            </Flex>
+          </ScrollArea>
+        </Card>
+      </Box>
+    </Flex>
+  );
+}
+
+function TelemetryDisplay({
+  telemetry,
+}: {
+  telemetry: CoreTelemetryPayload;
+}) {
+  return (
+    <Flex direction="column" gap="2">
+      <Text size="2" weight="medium">
+        Telemetry
+      </Text>
+      <Flex direction="column" gap="1">
+        <TelemetryRow label="Phase" value={PHASE_LABEL[telemetry.phase]} />
+        <TelemetryRow
+          label="Position"
+          value={`${(telemetry.position * 100).toFixed(1)}%`}
+        />
+        <TelemetryRow
+          label="Velocity"
+          value={`${(telemetry.velocity * 100).toFixed(1)}%`}
+        />
+        <TelemetryRow
+          label="Torque"
+          value={`${(telemetry.torque * 100).toFixed(1)}%`}
+        />
+        <TelemetryRow label="Sequence" value={String(telemetry.sequence)} />
+      </Flex>
+    </Flex>
+  );
+}
+
+function TelemetryRow({ label, value }: { label: string; value: string }) {
+  return (
+    <Flex justify="between">
+      <Text size="2" color="gray">
+        {label}
+      </Text>
+      <Text size="2" style={{ fontVariantNumeric: "tabular-nums" }}>
+        {value}
+      </Text>
+    </Flex>
+  );
+}

--- a/drivers/sim-motor/src/lib.rs
+++ b/drivers/sim-motor/src/lib.rs
@@ -1,11 +1,9 @@
 #![no_std]
 
 use core::convert::Infallible;
-use core::sync::atomic::{AtomicI32, Ordering};
 
 pub struct SimMotor {
     position: i32,
-    shared_position: &'static AtomicI32,
     enabled: bool,
 }
 
@@ -13,10 +11,9 @@ impl SimMotor {
     pub const STEPS_PER_REV: u32 = 32_768;
     pub const MAX_OUTPUT: u16 = 600;
 
-    pub fn new(shared_position: &'static AtomicI32) -> Self {
+    pub fn new() -> Self {
         Self {
             position: 0,
-            shared_position,
             enabled: false,
         }
     }
@@ -33,13 +30,11 @@ impl SimMotor {
 
     pub async fn home(&mut self) -> Result<(), Infallible> {
         self.position = 0;
-        self.shared_position.store(0, Ordering::Relaxed);
         Ok(())
     }
 
     pub async fn set_absolute_position(&mut self, steps: i32) -> Result<(), Infallible> {
         self.position = steps;
-        self.shared_position.store(steps, Ordering::Relaxed);
         Ok(())
     }
 

--- a/features/telemetry/Cargo.toml
+++ b/features/telemetry/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "telemetry"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+embassy-sync = { version = "0.7", default-features = false }
+embedded-io-async = "0.7"
+cobs = { version = "0.4", default-features = false }
+crc = { version = "3", default-features = false }
+log = "0.4"
+
+[dev-dependencies]
+ossm = { path = "../../ossm" }

--- a/features/telemetry/src/lib.rs
+++ b/features/telemetry/src/lib.rs
@@ -1,0 +1,4 @@
+#![no_std]
+
+pub mod protocol;
+pub mod transport;

--- a/features/telemetry/src/protocol.rs
+++ b/features/telemetry/src/protocol.rs
@@ -1,0 +1,166 @@
+use crc::{CRC_8_SMBUS, Crc};
+
+const CRC: Crc<u8> = Crc::<u8>::new(&CRC_8_SMBUS);
+
+/// Maximum payload size for any single frame (core or feature-specific).
+pub const MAX_PAYLOAD: usize = 64;
+
+/// Central registry of frame type IDs on the wire.
+///
+/// Every frame type across all features must be registered here to
+/// guarantee uniqueness at compile time.
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FrameType {
+    // Core (0x01–0x0F)
+    CoreTelemetry = 0x01,
+    // Feature frame types (0x10–0x1F)
+}
+
+impl FrameType {
+    pub fn from_u8(v: u8) -> Option<Self> {
+        match v {
+            0x01 => Some(Self::CoreTelemetry),
+            _ => None,
+        }
+    }
+}
+
+/// Maximum encoded frame size before COBS encoding.
+/// type(1) + payload(up to MAX_PAYLOAD) + crc(1)
+const MAX_RAW_FRAME: usize = 1 + MAX_PAYLOAD + 1;
+
+/// Maximum COBS-encoded frame size including the trailing zero delimiter.
+/// COBS expands at most 1 byte per 254 input bytes + 1 delimiter.
+pub const MAX_ENCODED_FRAME: usize = MAX_RAW_FRAME + (MAX_RAW_FRAME / 254) + 2;
+
+/// Encode a frame: [type] [payload...] [crc8], then COBS-encode.
+///
+/// Returns the number of bytes written to `out`, including the trailing
+/// zero delimiter.
+pub fn encode_frame(frame_type: u8, payload: &[u8], out: &mut [u8]) -> Result<usize, EncodeError> {
+    let raw_len = 1 + payload.len() + 1; // type + payload + crc
+    if raw_len > MAX_RAW_FRAME {
+        return Err(EncodeError::PayloadTooLarge);
+    }
+
+    let mut raw = [0u8; MAX_RAW_FRAME];
+    raw[0] = frame_type;
+    raw[1..1 + payload.len()].copy_from_slice(payload);
+
+    let mut digest = CRC.digest();
+    digest.update(&raw[..1 + payload.len()]);
+    raw[1 + payload.len()] = digest.finalize();
+
+    let cobs_len = cobs::encode(&raw[..raw_len], out);
+    // Append zero delimiter
+    if cobs_len + 1 > out.len() {
+        return Err(EncodeError::BufferTooSmall);
+    }
+    out[cobs_len] = 0x00;
+
+    Ok(cobs_len + 1)
+}
+
+/// Decode a COBS-encoded frame (without trailing zero delimiter).
+///
+/// Returns `(frame_type, payload_len)` with the payload written into `payload_out`.
+pub fn decode_frame(cobs_data: &[u8], payload_out: &mut [u8]) -> Result<(u8, usize), DecodeError> {
+    let mut raw = [0u8; MAX_RAW_FRAME];
+    let report = cobs::decode(cobs_data, &mut raw).map_err(|_| DecodeError::InvalidCobs)?;
+    let raw_len = report.frame_size();
+
+    if raw_len < 2 {
+        return Err(DecodeError::TooShort);
+    }
+
+    let frame_type = raw[0];
+    let payload_len = raw_len - 2; // minus type and crc
+    let received_crc = raw[raw_len - 1];
+
+    let mut digest = CRC.digest();
+    digest.update(&raw[..raw_len - 1]);
+    let computed_crc = digest.finalize();
+
+    if received_crc != computed_crc {
+        return Err(DecodeError::CrcMismatch);
+    }
+
+    if payload_len > payload_out.len() {
+        return Err(DecodeError::PayloadTooLarge);
+    }
+
+    payload_out[..payload_len].copy_from_slice(&raw[1..1 + payload_len]);
+    Ok((frame_type, payload_len))
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EncodeError {
+    PayloadTooLarge,
+    BufferTooSmall,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DecodeError {
+    InvalidCobs,
+    TooShort,
+    CrcMismatch,
+    PayloadTooLarge,
+}
+
+#[cfg(test)]
+mod tests {
+    use ossm::{CoreTelemetry, MotionPhase};
+
+    use super::*;
+
+    #[test]
+    fn frame_encode_decode_round_trip() {
+        let telemetry = CoreTelemetry {
+            position: 0.25,
+            velocity: 0.8,
+            torque: 0.6,
+            phase: MotionPhase::Paused,
+            sequence: 1000,
+        };
+
+        let mut payload = [0u8; CoreTelemetry::SIZE];
+        telemetry.to_bytes(&mut payload);
+
+        let mut encoded = [0u8; MAX_ENCODED_FRAME];
+        let len = encode_frame(FrameType::CoreTelemetry as u8, &payload, &mut encoded).unwrap();
+
+        let cobs_data = &encoded[..len - 1];
+        let mut decoded_payload = [0u8; MAX_PAYLOAD];
+        let (frame_type, payload_len) = decode_frame(cobs_data, &mut decoded_payload).unwrap();
+
+        assert_eq!(frame_type, FrameType::CoreTelemetry as u8);
+        assert_eq!(payload_len, CoreTelemetry::SIZE);
+
+        let decoded =
+            CoreTelemetry::from_bytes(decoded_payload[..CoreTelemetry::SIZE].try_into().unwrap());
+        assert_eq!(decoded.position, telemetry.position);
+        assert_eq!(decoded.velocity, telemetry.velocity);
+        assert_eq!(decoded.phase, telemetry.phase);
+        assert_eq!(decoded.sequence, telemetry.sequence);
+    }
+
+    #[test]
+    fn corrupt_crc_rejected() {
+        let payload = [0x42; 8];
+
+        let mut encoded = [0u8; MAX_ENCODED_FRAME];
+        let len = encode_frame(FrameType::CoreTelemetry as u8, &payload, &mut encoded).unwrap();
+
+        encoded[1] ^= 0xFF;
+
+        let cobs_data = &encoded[..len - 1];
+        let mut decoded_payload = [0u8; MAX_PAYLOAD];
+        let result = decode_frame(cobs_data, &mut decoded_payload);
+
+        assert!(matches!(
+            result,
+            Err(DecodeError::CrcMismatch) | Err(DecodeError::InvalidCobs)
+        ));
+    }
+}

--- a/features/telemetry/src/transport.rs
+++ b/features/telemetry/src/transport.rs
@@ -1,0 +1,56 @@
+use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
+use embassy_sync::channel::Channel;
+use embedded_io_async::Write;
+use log::error;
+
+use crate::protocol::{self, EncodeError, FrameType, MAX_ENCODED_FRAME};
+
+/// A pre-encoded frame ready for transmission.
+pub struct EncodedFrame {
+    buf: [u8; MAX_ENCODED_FRAME],
+    len: usize,
+}
+
+/// Channel for submitting frames to the telemetry writer.
+///
+/// Capacity of 8 frames. Producers use [`TelemetrySender::send`] which
+/// drops the frame silently if the channel is full.
+pub type TelemetryChannel = Channel<CriticalSectionRawMutex, EncodedFrame, 8>;
+
+/// Handle for features to send telemetry frames.
+pub struct TelemetrySender {
+    channel: &'static TelemetryChannel,
+}
+
+impl TelemetrySender {
+    pub fn new(channel: &'static TelemetryChannel) -> Self {
+        Self { channel }
+    }
+
+    /// Encode and enqueue a frame. Drops silently if the channel is full.
+    pub fn send(&self, frame_type: FrameType, payload: &[u8]) -> Result<(), EncodeError> {
+        let mut frame = EncodedFrame {
+            buf: [0u8; MAX_ENCODED_FRAME],
+            len: 0,
+        };
+
+        frame.len = protocol::encode_frame(frame_type as u8, payload, &mut frame.buf)?;
+        let _ = self.channel.try_send(frame);
+
+        Ok(())
+    }
+}
+
+/// Writer task: drains the channel and writes frames to the wire.
+pub async fn tx_task<W: Write>(
+    mut writer: W,
+    channel: &'static TelemetryChannel,
+) -> ! {
+    loop {
+        let frame = channel.receive().await;
+
+        if let Err(e) = writer.write_all(&frame.buf[..frame.len]).await {
+            error!("Telemetry TX write error: {:?}", e);
+        }
+    }
+}

--- a/firmware/ossm-alt/Cargo.toml
+++ b/firmware/ossm-alt/Cargo.toml
@@ -15,6 +15,7 @@ ossm-m5-remote = { path = "../../features/ossm-m5-remote", features = [
 ble-remote = { path = "../../features/ble-remote", features = [
     "esp32s3",
 ] }
+telemetry = { path = "../../features/telemetry" }
 
 esp-hal = { version = "~1.0", features = ["log-04", "esp32s3", "unstable"] }
 

--- a/firmware/ossm-alt/src/main.rs
+++ b/firmware/ossm-alt/src/main.rs
@@ -20,6 +20,7 @@ use esp_hal::{
     system::Stack,
     timer::timg::TimerGroup,
     uart::{Config, Uart},
+    usb_serial_jtag::UsbSerialJtag,
 };
 use esp_radio::ble::controller::BleConnector;
 use esp_radio::esp_now::{EspNowManager, EspNowSender};
@@ -29,6 +30,7 @@ use m57aim_motor::{Modbus, Motor57AIM, Motor57AIMConfig};
 use ossm::{MechanicalConfig, MotionController, MotionLimits, Ossm};
 
 use ossm_m5_remote::RemoteConfig;
+use telemetry::transport::{TelemetryChannel, TelemetrySender};
 use rs485_board::{Rs485, Rs485Board, Rs485ModbusTransport};
 
 use pattern_engine::{AnyPattern, PatternEngine};
@@ -56,8 +58,11 @@ type ConcreteTransport =
 type ConcreteMotor = Motor57AIM<Modbus<ConcreteTransport>, Delay>;
 type ConcreteBoard = Rs485Board<ConcreteMotor>;
 
+const TELEMETRY_ENABLED: bool = true;
+
 static OSSM: Ossm = Ossm::new();
 static PATTERNS: PatternEngine = PatternEngine::new(&OSSM);
+static TELEMETRY_CHANNEL: TelemetryChannel = TelemetryChannel::new();
 
 static EXECUTOR_CORE_1: StaticCell<InterruptExecutor<2>> = StaticCell::new();
 static APP_CORE_STACK: StaticCell<Stack<16384>> = StaticCell::new();
@@ -76,11 +81,24 @@ async fn motion_task(mut controller: MotionController<'static, ConcreteBoard>) {
     }
 }
 
+#[embassy_executor::task]
+async fn telemetry_writer_task(writer: UsbSerialJtag<'static, esp_hal::Async>) {
+    telemetry::transport::tx_task(writer, &TELEMETRY_CHANNEL).await;
+}
+
+#[embassy_executor::task]
+async fn core_telemetry_task() {
+    let sender = TelemetrySender::new(&TELEMETRY_CHANNEL);
+    ossm::telemetry::telemetry_task(&OSSM, &sender).await;
+}
+
 #[esp_rtos::main]
 async fn main(spawner: Spawner) {
-    ossm::logging::init(log::LevelFilter::Info, |line| {
-        esp_println::println!("{}", line);
-    });
+    if !TELEMETRY_ENABLED {
+        ossm::logging::init(log::LevelFilter::Info, |line| {
+            esp_println::println!("{}", line);
+        });
+    }
 
     ossm::build_info!();
 
@@ -188,6 +206,12 @@ async fn main(spawner: Spawner) {
     let connector = BleConnector::new(radio, p.BT, Default::default())
         .expect("Could not create BleConnector");
     ble_remote::start(&spawner, connector, &PATTERNS);
+
+    if TELEMETRY_ENABLED {
+        let usb_serial = UsbSerialJtag::new(p.USB_DEVICE).into_async();
+        spawner.spawn(telemetry_writer_task(usb_serial)).unwrap();
+        spawner.spawn(core_telemetry_task()).unwrap();
+    }
 
     let mut pattern_runner = PATTERNS.runner(AnyPattern::all_builtin());
     pattern_runner.run(Delay).await;

--- a/firmware/ossm-alt/src/main.rs
+++ b/firmware/ossm-alt/src/main.rs
@@ -28,8 +28,8 @@ use log::info;
 use m57aim_motor::{Modbus, Motor57AIM, Motor57AIMConfig};
 use ossm::{MechanicalConfig, MotionController, MotionLimits, Ossm};
 
-use rs485_board::{Rs485Board, Rs485, Rs485ModbusTransport};
 use ossm_m5_remote::RemoteConfig;
+use rs485_board::{Rs485, Rs485Board, Rs485ModbusTransport};
 
 use pattern_engine::{AnyPattern, PatternEngine};
 use static_cell::StaticCell;
@@ -176,7 +176,14 @@ async fn main(spawner: Spawner) {
         max_travel_mm: limits.max_position_mm - limits.min_position_mm,
     };
 
-    ossm_m5_remote::start(&spawner, manager, sender, receiver, &PATTERNS, remote_config);
+    ossm_m5_remote::start(
+        &spawner,
+        manager,
+        sender,
+        receiver,
+        &PATTERNS,
+        remote_config,
+    );
 
     let connector = BleConnector::new(radio, p.BT, Default::default())
         .expect("Could not create BleConnector");

--- a/firmware/sim-wasm/src/lib.rs
+++ b/firmware/sim-wasm/src/lib.rs
@@ -1,5 +1,3 @@
-use core::sync::atomic::{AtomicI32, Ordering};
-
 use embassy_time::{Delay, Duration, Ticker};
 extern crate alloc;
 use alloc::string::String;
@@ -12,7 +10,6 @@ use wasm_bindgen::prelude::*;
 
 static OSSM: Ossm = Ossm::new();
 static PATTERNS: PatternEngine = PatternEngine::new(&OSSM);
-static MOTOR_POSITION: AtomicI32 = AtomicI32::new(0);
 
 static MECHANICAL: MechanicalConfig = MechanicalConfig {
     pulley_teeth: 20,
@@ -20,11 +17,7 @@ static MECHANICAL: MechanicalConfig = MechanicalConfig {
 };
 
 #[wasm_bindgen]
-pub struct Simulator {
-    steps_per_mm: f64,
-    min_position_mm: f64,
-    max_position_mm: f64,
-}
+pub struct Simulator {}
 
 #[wasm_bindgen]
 impl Simulator {
@@ -40,7 +33,7 @@ impl Simulator {
         ossm::build_info!();
 
         let update_interval_secs = update_interval_ms / 1000.0;
-        let motor = SimMotor::new(&MOTOR_POSITION);
+        let motor = SimMotor::new();
         let board = SimBoard::new(motor, &MECHANICAL);
 
         let limits = MotionLimits {
@@ -49,7 +42,7 @@ impl Simulator {
             ..MotionLimits::default()
         };
 
-        let mut controller = OSSM.controller(board, limits.clone(), update_interval_secs);
+        let mut controller = OSSM.controller(board, limits, update_interval_secs);
 
         let interval_us = (update_interval_secs * 1_000_000.0) as u64;
 
@@ -69,13 +62,7 @@ impl Simulator {
             pattern_runner.run(Delay).await;
         });
 
-        let steps_per_mm = MECHANICAL.steps_per_mm(SimMotor::STEPS_PER_REV) as f64;
-
-        Self {
-            steps_per_mm,
-            min_position_mm: limits.min_position_mm,
-            max_position_mm: limits.max_position_mm,
-        }
+        Self {}
     }
 
     /// Engine state: 0 = idle, 1 = homing, 2 = playing, 3 = paused.
@@ -85,10 +72,7 @@ impl Simulator {
 
     /// Current position as a fraction of the machine range (0.0-1.0).
     pub fn get_position(&self) -> f64 {
-        let steps = MOTOR_POSITION.load(Ordering::Relaxed);
-        let mm = steps as f64 / self.steps_per_mm;
-        let range = self.max_position_mm - self.min_position_mm;
-        (mm - self.min_position_mm) / range
+        OSSM.motion_state().position as f64
     }
 
     /// Set the maximum depth as a fraction of the machine range (0.0-1.0).

--- a/firmware/waveshare/Cargo.toml
+++ b/firmware/waveshare/Cargo.toml
@@ -7,8 +7,9 @@ rust-version = "1.88"
 [dependencies]
 ossm = { path = "../../ossm" }
 pattern-engine = { path = "../../features/pattern-engine" }
-m57aim-motor = { path = "../../drivers/m57aim" }
-rs485-board = { path = "../../boards/rs485" }
+telemetry = { path = "../../features/telemetry" }
+sim-motor = { path = "../../drivers/sim-motor" }
+sim-board = { path = "../../boards/sim-board" }
 ossm-m5-remote = { path = "../../features/ossm-m5-remote", features = [
     "esp32s3",
 ] }
@@ -17,6 +18,7 @@ ble-remote = { path = "../../features/ble-remote", features = [
 ] }
 
 esp-hal = { version = "~1.0", features = ["log-04", "esp32s3", "unstable"] }
+embedded-io-async = "0.7"
 
 esp-radio = { version = "0.17.0", default-features = false, features = [
     "ble",

--- a/firmware/waveshare/src/main.rs
+++ b/firmware/waveshare/src/main.rs
@@ -14,22 +14,20 @@ use embassy_sync::signal::Signal;
 use embassy_time::Delay;
 use embassy_time::{Duration, Ticker};
 use esp_hal::{
-    Blocking,
-    gpio::{Level, Output, OutputConfig},
     interrupt::{Priority, software::SoftwareInterruptControl},
     system::Stack,
     timer::timg::TimerGroup,
-    uart::{Config, Uart},
+    usb_serial_jtag::UsbSerialJtag,
 };
 use esp_radio::ble::controller::BleConnector;
 use esp_radio::esp_now::{EspNowManager, EspNowSender};
 use esp_rtos::embassy::InterruptExecutor;
 use log::info;
-use m57aim_motor::{Modbus, Motor57AIM, Motor57AIMConfig};
 use ossm::{MechanicalConfig, MotionController, MotionLimits, Ossm};
-
-use rs485_board::{Rs485Board, Rs485, Rs485ModbusTransport};
+use sim_board::SimBoard;
+use sim_motor::SimMotor;
 use ossm_m5_remote::RemoteConfig;
+use telemetry::transport::{TelemetryChannel, TelemetrySender};
 
 use pattern_engine::{AnyPattern, PatternEngine};
 use static_cell::StaticCell;
@@ -41,8 +39,6 @@ extern crate alloc;
 esp_bootloader_esp_idf::esp_app_desc!();
 
 const UPDATE_INTERVAL_SECS: f64 = 0.01;
-const MOTOR_BAUD_RATE: u32 = 115_200;
-const DEVICE_ADDR: u8 = 0x01;
 
 macro_rules! mk_static {
     ($t:ty, $val:expr) => {{
@@ -51,13 +47,13 @@ macro_rules! mk_static {
     }};
 }
 
-type ConcreteTransport =
-    Rs485ModbusTransport<Rs485<Uart<'static, Blocking>, Output<'static>>, Delay>;
-type ConcreteMotor = Motor57AIM<Modbus<ConcreteTransport>, Delay>;
-type ConcreteBoard = Rs485Board<ConcreteMotor>;
+type ConcreteBoard = SimBoard;
+
+const TELEMETRY_ENABLED: bool = true;
 
 static OSSM: Ossm = Ossm::new();
 static PATTERNS: PatternEngine = PatternEngine::new(&OSSM);
+static TELEMETRY_CHANNEL: TelemetryChannel = TelemetryChannel::new();
 
 static EXECUTOR_CORE_1: StaticCell<InterruptExecutor<2>> = StaticCell::new();
 static APP_CORE_STACK: StaticCell<Stack<16384>> = StaticCell::new();
@@ -76,11 +72,24 @@ async fn motion_task(mut controller: MotionController<'static, ConcreteBoard>) {
     }
 }
 
+#[embassy_executor::task]
+async fn telemetry_writer_task(writer: UsbSerialJtag<'static, esp_hal::Async>) {
+    telemetry::transport::tx_task(writer, &TELEMETRY_CHANNEL).await;
+}
+
+#[embassy_executor::task]
+async fn core_telemetry_task() {
+    let sender = TelemetrySender::new(&TELEMETRY_CHANNEL);
+    ossm::telemetry::telemetry_task(&OSSM, &sender).await;
+}
+
 #[esp_rtos::main]
 async fn main(spawner: Spawner) {
-    ossm::logging::init(log::LevelFilter::Info, |line| {
-        esp_println::println!("{}", line);
-    });
+    if !TELEMETRY_ENABLED {
+        ossm::logging::init(log::LevelFilter::Info, |line| {
+            esp_println::println!("{}", line);
+        });
+    }
 
     ossm::build_info!();
 
@@ -91,29 +100,14 @@ async fn main(spawner: Spawner) {
     let timg0 = TimerGroup::new(p.TIMG0);
     esp_rtos::start(timg0.timer0);
 
-    let uart_config = Config::default().with_baudrate(MOTOR_BAUD_RATE);
-    let uart = Uart::new(p.UART1, uart_config)
-        .expect("Failed to initialize UART")
-        .with_tx(p.GPIO17)
-        .with_rx(p.GPIO18);
-
-    let de = Output::new(p.GPIO21, Level::Low, OutputConfig::default());
-    let rs485 = Rs485::new(uart, de);
-
-    let transport = Rs485ModbusTransport::new(rs485, Delay);
-    let motor = Motor57AIM::new(
-        Modbus::new(transport, DEVICE_ADDR),
-        Motor57AIMConfig::default(),
-        Delay,
-    );
-
     static MECHANICAL: MechanicalConfig = MechanicalConfig {
         pulley_teeth: 20,
         belt_pitch_mm: 2.0,
     };
     let limits = MotionLimits::default();
 
-    let board = Rs485Board::new(motor, &MECHANICAL);
+    let motor = SimMotor::new();
+    let board = SimBoard::new(motor, &MECHANICAL);
     let controller = OSSM.controller(board, limits.clone(), UPDATE_INTERVAL_SECS);
 
     let sw_int = SoftwareInterruptControl::new(p.SW_INTERRUPT);
@@ -178,6 +172,12 @@ async fn main(spawner: Spawner) {
     let connector = BleConnector::new(radio, p.BT, Default::default())
         .expect("Could not create BleConnector");
     ble_remote::start(&spawner, connector, &PATTERNS);
+
+    if TELEMETRY_ENABLED {
+        let usb_serial = UsbSerialJtag::new(p.USB_DEVICE).into_async();
+        spawner.spawn(telemetry_writer_task(usb_serial)).unwrap();
+        spawner.spawn(core_telemetry_task()).unwrap();
+    }
 
     let mut pattern_runner = PATTERNS.runner(AnyPattern::all_builtin());
     pattern_runner.run(Delay).await;

--- a/justfile
+++ b/justfile
@@ -42,6 +42,10 @@ build-wasm:
 dev-patterns: build-wasm
     pnpm dev --host
 
+# Run unit tests on the host (overrides any .cargo target symlink)
+test *ARGS:
+    cargo +stable test --target "$(rustc +stable -vV | awk '/^host:/ {print $2}')" {{ ARGS }}
+
 # All
 [parallel]
 build-all: build-ossm-alt build-waveshare build-seeed-xiao build-wasm

--- a/ossm/Cargo.toml
+++ b/ossm/Cargo.toml
@@ -14,6 +14,8 @@ embedded-hal = "1.0"
 embedded-hal-async = "1.0"
 embedded-io = "0.7.1"
 heapless = "0.9.2"
+embassy-futures = { version = "0.1", default-features = false }
 log = "0.4"
+telemetry = { path = "../features/telemetry" }
 rmodbus = { version = "0.12.2", default-features = false, features = ["heapless"] }
 crc = { version = "3", default-features = false }

--- a/ossm/src/command.rs
+++ b/ossm/src/command.rs
@@ -2,6 +2,8 @@ use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_sync::channel::Channel;
 use embassy_sync::signal::Signal;
 
+use crate::state::MotionStateChannels;
+
 pub(crate) type MoveChannel = Channel<CriticalSectionRawMutex, MotionCommand, 1>;
 pub(crate) type StateChannel = Channel<CriticalSectionRawMutex, StateCommand, 1>;
 pub(crate) type StateResponseSignal = Signal<CriticalSectionRawMutex, StateResponse>;
@@ -12,6 +14,7 @@ pub(crate) struct OssmChannels {
     pub(crate) state_cmd: StateChannel,
     pub(crate) state_resp: StateResponseSignal,
     pub(crate) move_resp: MoveResponseSignal,
+    pub(crate) motion_state: MotionStateChannels,
 }
 
 impl OssmChannels {
@@ -21,6 +24,7 @@ impl OssmChannels {
             state_cmd: StateChannel::new(),
             state_resp: StateResponseSignal::new(),
             move_resp: MoveResponseSignal::new(),
+            motion_state: MotionStateChannels::new(),
         }
     }
 }

--- a/ossm/src/lib.rs
+++ b/ossm/src/lib.rs
@@ -10,6 +10,7 @@ mod mechanical;
 mod motion;
 mod motor;
 mod state;
+pub mod telemetry;
 pub mod transport;
 
 pub use board::Board;
@@ -20,6 +21,7 @@ pub use mechanical::MechanicalConfig;
 pub use motion::MotionController;
 pub use motor::{Motor, Rs485Motor, SelfHoming, StepDir};
 pub use state::{MotionPhase, MotionState};
+pub use telemetry::CoreTelemetry;
 pub use transport::{
     Modbus, ModbusTransport, Rs485, Rs485ModbusTransport, StepDirConfig, StepDirError,
     StepDirMotor, StepOutput, TransportError,

--- a/ossm/src/lib.rs
+++ b/ossm/src/lib.rs
@@ -9,6 +9,7 @@ pub mod logging;
 mod mechanical;
 mod motion;
 mod motor;
+mod state;
 pub mod transport;
 
 pub use board::Board;
@@ -18,6 +19,7 @@ pub use limits::MotionLimits;
 pub use mechanical::MechanicalConfig;
 pub use motion::MotionController;
 pub use motor::{Motor, Rs485Motor, SelfHoming, StepDir};
+pub use state::{MotionPhase, MotionState};
 pub use transport::{
     Modbus, ModbusTransport, Rs485, Rs485ModbusTransport, StepDirConfig, StepDirError,
     StepDirMotor, StepOutput, TransportError,
@@ -93,5 +95,30 @@ impl Ossm {
     /// Wait for the current in-flight motion to complete.
     pub async fn await_motion(&self) -> Result<(), Cancelled> {
         self.channels.move_resp.wait().await
+    }
+
+    /// Read the current motion state (position, velocity, torque, phase).
+    pub fn motion_state(&self) -> MotionState {
+        self.channels.motion_state.get()
+    }
+
+    /// Create an async subscriber that receives [`MotionPhase`] on every
+    /// phase transition.
+    ///
+    /// Returns `Err` if all subscriber slots are in use.
+    pub fn phase_subscriber(
+        &self,
+    ) -> Result<
+        embassy_sync::pubsub::Subscriber<
+            '_,
+            embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex,
+            MotionPhase,
+            1,
+            8,
+            0,
+        >,
+        embassy_sync::pubsub::Error,
+    > {
+        self.channels.motion_state.phase_subscriber()
     }
 }

--- a/ossm/src/motion.rs
+++ b/ossm/src/motion.rs
@@ -1,6 +1,7 @@
 use rsruckig::prelude::*;
 
 use crate::command::{Cancelled, MotionCommand, OssmChannels, StateCommand, StateResponse};
+use crate::state::MotionPhase;
 use crate::{Board, MotionLimits};
 
 // Floor applied to velocity requests to prevent degenerate Ruckig inputs.
@@ -123,17 +124,20 @@ impl<'a, B: Board> MotionController<'a, B> {
 
     async fn process_state_command(&mut self, cmd: StateCommand) -> Result<(), B::Error> {
         match (&self.state, cmd) {
-            (MotionState::Disabled, StateCommand::Enable) => match self.board.enable().await {
-                Ok(()) => {
-                    self.state = MotionState::Enabled;
-                    self.respond(StateResponse::Completed);
+            (MotionState::Disabled, StateCommand::Enable) => {
+                match self.board.enable().await {
+                    Ok(()) => {
+                        self.state = MotionState::Enabled;
+                        self.publish_phase_transition();
+                        self.respond(StateResponse::Completed);
+                    }
+                    Err(e) => {
+                        log::error!("Board enable failed: {:?}", e);
+                        self.respond(StateResponse::Fault);
+                        return Err(e);
+                    }
                 }
-                Err(e) => {
-                    log::error!("Board enable failed: {:?}", e);
-                    self.respond(StateResponse::Fault);
-                    return Err(e);
-                }
-            },
+            }
             // Idempotent: already in the target state, nothing to do.
             // BLE remote RADR thrashes sometimes causing the catch-all
             // to trigger.
@@ -206,6 +210,7 @@ impl<'a, B: Board> MotionController<'a, B> {
                 self.set_motion_target(cmd);
                 self.apply_torque().await;
                 self.state = MotionState::Moving;
+                self.publish_phase_transition();
             }
 
             MotionState::Moving => {
@@ -237,11 +242,13 @@ impl<'a, B: Board> MotionController<'a, B> {
             log::error!("Board set_position failed: {:?}", e);
         }
         self.output.pass_to_input(&mut self.input);
+        self.publish_state();
 
         if result == RuckigResult::Finished {
             match self.state {
                 MotionState::Stopping(StopReason::Pause) => {
                     self.state = MotionState::Paused;
+                    self.publish_phase_transition();
                 }
                 MotionState::Stopping(StopReason::Disable) => {
                     self.disable().await;
@@ -258,6 +265,7 @@ impl<'a, B: Board> MotionController<'a, B> {
                     self.target = None;
                     self.state = MotionState::Ready;
                     self.channels.move_resp.signal(Ok(()));
+                    self.publish_phase_transition();
                 }
             }
         }
@@ -272,6 +280,7 @@ impl<'a, B: Board> MotionController<'a, B> {
 
         if let Err(e) = self.board.home().await {
             log::error!("Board home failed: {:?}", e);
+            self.publish_phase_transition();
             return Err(e);
         }
 
@@ -288,6 +297,7 @@ impl<'a, B: Board> MotionController<'a, B> {
 
         self.target = None;
         self.state = MotionState::Ready;
+        self.publish_phase_transition();
         Ok(())
     }
 
@@ -300,6 +310,7 @@ impl<'a, B: Board> MotionController<'a, B> {
         self.input.control_interface = ControlInterface::Position;
         self.target = None;
         self.state = MotionState::Disabled;
+        self.publish_phase_transition();
     }
 
     fn stop(&mut self, reason: StopReason) {
@@ -309,6 +320,7 @@ impl<'a, B: Board> MotionController<'a, B> {
         self.input.target_velocity[0] = 0.0;
         self.output.time = 0.0;
         self.state = MotionState::Stopping(reason);
+        self.publish_phase_transition();
     }
 
     async fn resume(&mut self) {
@@ -317,6 +329,7 @@ impl<'a, B: Board> MotionController<'a, B> {
         self.sync_ruckig();
         self.apply_torque().await;
         self.state = MotionState::Moving;
+        self.publish_phase_transition();
     }
 
     /// Cancel any in-flight motion and transition to `Disabled`.
@@ -338,6 +351,7 @@ impl<'a, B: Board> MotionController<'a, B> {
         }
         self.target = None;
         self.state = MotionState::Disabled;
+        self.publish_phase_transition();
     }
 
     fn respond(&self, resp: StateResponse) {
@@ -380,5 +394,50 @@ impl<'a, B: Board> MotionController<'a, B> {
         if let Err(e) = self.board.set_torque(fraction).await {
             log::error!("Board set_torque failed: {:?}", e);
         }
+    }
+
+    fn phase(&self) -> MotionPhase {
+        match self.state {
+            MotionState::Disabled => MotionPhase::Disabled,
+            MotionState::Enabled => MotionPhase::Enabled,
+            MotionState::Ready => MotionPhase::Ready,
+            MotionState::Moving => MotionPhase::Moving,
+            MotionState::Stopping(_) => MotionPhase::Stopping,
+            MotionState::Paused => MotionPhase::Paused,
+        }
+    }
+
+    fn mm_to_fraction(&self, mm: f64) -> f32 {
+        let range = self.limits.max_position_mm - self.limits.min_position_mm;
+        if range <= 0.0 {
+            return 0.0;
+        }
+        ((mm - self.limits.min_position_mm) / range) as f32
+    }
+
+    fn velocity_to_fraction(&self, mm_s: f64) -> f32 {
+        if self.limits.max_velocity_mm_s <= 0.0 {
+            return 0.0;
+        }
+        (mm_s / self.limits.max_velocity_mm_s) as f32
+    }
+
+    fn publish_state(&self) {
+        let position_mm = self.output.new_position[0]
+            .clamp(self.limits.min_position_mm, self.limits.max_position_mm);
+        let velocity_mm_s = self.output.new_velocity[0];
+        let torque = self.target.as_ref().and_then(|t| t.torque).unwrap_or(1.0);
+
+        self.channels.motion_state.update(crate::state::MotionState {
+            phase: self.phase(),
+            position: self.mm_to_fraction(position_mm),
+            velocity: self.velocity_to_fraction(velocity_mm_s.abs()),
+            torque: torque as f32,
+        });
+    }
+
+    fn publish_phase_transition(&self) {
+        self.publish_state();
+        self.channels.motion_state.publish_phase(self.phase());
     }
 }

--- a/ossm/src/state.rs
+++ b/ossm/src/state.rs
@@ -14,6 +14,31 @@ pub enum MotionPhase {
     Paused,
 }
 
+impl MotionPhase {
+    pub fn to_u8(self) -> u8 {
+        match self {
+            Self::Disabled => 0,
+            Self::Enabled => 1,
+            Self::Ready => 2,
+            Self::Moving => 3,
+            Self::Stopping => 4,
+            Self::Paused => 5,
+        }
+    }
+
+    pub fn from_u8(v: u8) -> Self {
+        match v {
+            0 => Self::Disabled,
+            1 => Self::Enabled,
+            2 => Self::Ready,
+            3 => Self::Moving,
+            4 => Self::Stopping,
+            5 => Self::Paused,
+            _ => Self::Disabled,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 pub struct MotionState {
     pub phase: MotionPhase,

--- a/ossm/src/state.rs
+++ b/ossm/src/state.rs
@@ -1,0 +1,81 @@
+use core::cell::Cell;
+
+use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
+use embassy_sync::blocking_mutex::Mutex;
+use embassy_sync::pubsub::{self, PubSubChannel};
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum MotionPhase {
+    Disabled,
+    Enabled,
+    Ready,
+    Moving,
+    Stopping,
+    Paused,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct MotionState {
+    pub phase: MotionPhase,
+    /// Current position as a fraction of the machine range (0.0–1.0).
+    pub position: f32,
+    /// Current velocity as a fraction of max velocity (0.0–1.0).
+    pub velocity: f32,
+    /// Current torque limit as a fraction (0.0–1.0).
+    pub torque: f32,
+}
+
+impl MotionState {
+    pub(crate) const fn new() -> Self {
+        Self {
+            phase: MotionPhase::Disabled,
+            position: 0.0,
+            velocity: 0.0,
+            torque: 0.0,
+        }
+    }
+}
+
+/// Broadcast channel for [`MotionPhase`] transitions.
+///
+/// Uses `PubSubChannel` so subscribers can be created and dropped
+/// dynamically as services start and stop.
+///
+/// - `CAP = 1`: only the latest transition matters; older messages are dropped.
+/// - `SUBS = 8`: up to 8 concurrent async subscribers.
+/// - `PUBS = 0`: publishing uses [`PubSubChannel::immediate_publisher()`]
+///   which does not consume a publisher slot.
+type PhaseChannel = PubSubChannel<CriticalSectionRawMutex, MotionPhase, 1, 8, 0>;
+
+pub(crate) struct MotionStateChannels {
+    state: Mutex<CriticalSectionRawMutex, Cell<MotionState>>,
+    phase: PhaseChannel,
+}
+
+impl MotionStateChannels {
+    pub(crate) const fn new() -> Self {
+        Self {
+            state: Mutex::new(Cell::new(MotionState::new())),
+            phase: PhaseChannel::new(),
+        }
+    }
+
+    pub(crate) fn update(&self, new_state: MotionState) {
+        self.state.lock(|cell| cell.set(new_state));
+    }
+
+    pub(crate) fn publish_phase(&self, phase: MotionPhase) {
+        self.phase.immediate_publisher().publish_immediate(phase);
+    }
+
+    pub fn get(&self) -> MotionState {
+        self.state.lock(|cell| cell.get())
+    }
+
+    pub fn phase_subscriber(
+        &self,
+    ) -> Result<pubsub::Subscriber<'_, CriticalSectionRawMutex, MotionPhase, 1, 8, 0>, pubsub::Error>
+    {
+        self.phase.subscriber()
+    }
+}

--- a/ossm/src/telemetry.rs
+++ b/ossm/src/telemetry.rs
@@ -1,0 +1,121 @@
+use embassy_futures::select;
+use embassy_time::{Duration, Ticker};
+use telemetry::protocol::FrameType;
+use telemetry::transport::TelemetrySender;
+
+use crate::Ossm;
+use crate::state::MotionPhase;
+use crate::state::MotionState;
+
+/// Wire-format telemetry payload for core motion state (device → browser).
+///
+/// Fixed 15-byte layout:
+/// ```text
+/// position: f32 LE  [0..4]
+/// velocity: f32 LE  [4..8]
+/// torque:   f32 LE  [8..12]
+/// phase:    u8       [12]
+/// sequence: u16 LE   [13..15]
+/// ```
+#[derive(Debug, Clone, Copy)]
+pub struct CoreTelemetry {
+    pub position: f32,
+    pub velocity: f32,
+    pub torque: f32,
+    pub phase: MotionPhase,
+    pub sequence: u16,
+}
+
+impl CoreTelemetry {
+    pub const SIZE: usize = 15;
+
+    pub fn from_state(state: &MotionState, sequence: u16) -> Self {
+        Self {
+            position: state.position,
+            velocity: state.velocity,
+            torque: state.torque,
+            phase: state.phase,
+            sequence,
+        }
+    }
+
+    pub fn to_bytes(&self, buf: &mut [u8; Self::SIZE]) {
+        buf[0..4].copy_from_slice(&self.position.to_le_bytes());
+        buf[4..8].copy_from_slice(&self.velocity.to_le_bytes());
+        buf[8..12].copy_from_slice(&self.torque.to_le_bytes());
+        buf[12] = self.phase.to_u8();
+        buf[13..15].copy_from_slice(&self.sequence.to_le_bytes());
+    }
+
+    pub fn from_bytes(buf: &[u8; Self::SIZE]) -> Self {
+        Self {
+            position: f32::from_le_bytes([buf[0], buf[1], buf[2], buf[3]]),
+            velocity: f32::from_le_bytes([buf[4], buf[5], buf[6], buf[7]]),
+            torque: f32::from_le_bytes([buf[8], buf[9], buf[10], buf[11]]),
+            phase: MotionPhase::from_u8(buf[12]),
+            sequence: u16::from_le_bytes([buf[13], buf[14]]),
+        }
+    }
+}
+
+/// Produces core telemetry frames, emitting only when state changes.
+///
+/// Wakes on phase transitions (via pubsub) or a 20ms poll tick.
+/// Skips sending if nothing has changed since the last frame.
+pub async fn telemetry_task(ossm: &'static Ossm, sender: &TelemetrySender) -> ! {
+    let mut phase_sub = ossm.phase_subscriber().expect("No subscriber slots available");
+    let mut ticker = Ticker::every(Duration::from_millis(20));
+    let mut sequence: u16 = 0;
+    let mut last_state: Option<MotionState> = None;
+
+    loop {
+        select::select(phase_sub.next_message_pure(), ticker.next()).await;
+
+        let state = ossm.motion_state();
+
+        if let Some(prev) = &last_state {
+            if state.phase == prev.phase
+                && state.position == prev.position
+                && state.velocity == prev.velocity
+                && state.torque == prev.torque
+            {
+                continue;
+            }
+        }
+
+        last_state = Some(state);
+
+        let telem = CoreTelemetry::from_state(&state, sequence);
+        let mut payload = [0u8; CoreTelemetry::SIZE];
+        telem.to_bytes(&mut payload);
+        let _ = sender.send(FrameType::CoreTelemetry, &payload);
+
+        sequence = sequence.wrapping_add(1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn core_telemetry_round_trip() {
+        let original = CoreTelemetry {
+            position: 0.75,
+            velocity: 0.5,
+            torque: 1.0,
+            phase: MotionPhase::Moving,
+            sequence: 42,
+        };
+
+        let mut payload = [0u8; CoreTelemetry::SIZE];
+        original.to_bytes(&mut payload);
+
+        let decoded = CoreTelemetry::from_bytes(&payload);
+        assert_eq!(decoded.position, original.position);
+        assert_eq!(decoded.velocity, original.velocity);
+        assert_eq!(decoded.torque, original.torque);
+        assert_eq!(decoded.phase, original.phase);
+        assert_eq!(decoded.sequence, original.sequence);
+    }
+}

--- a/ossm/src/telemetry.rs
+++ b/ossm/src/telemetry.rs
@@ -1,4 +1,3 @@
-use embassy_futures::select;
 use embassy_time::{Duration, Ticker};
 use telemetry::protocol::FrameType;
 use telemetry::transport::TelemetrySender;
@@ -58,32 +57,15 @@ impl CoreTelemetry {
     }
 }
 
-/// Produces core telemetry frames, emitting only when state changes.
-///
-/// Wakes on phase transitions (via pubsub) or a 20ms poll tick.
-/// Skips sending if nothing has changed since the last frame.
+/// Produces core telemetry frames at a fixed 50Hz (20ms) interval.
 pub async fn telemetry_task(ossm: &'static Ossm, sender: &TelemetrySender) -> ! {
-    let mut phase_sub = ossm.phase_subscriber().expect("No subscriber slots available");
     let mut ticker = Ticker::every(Duration::from_millis(20));
     let mut sequence: u16 = 0;
-    let mut last_state: Option<MotionState> = None;
 
     loop {
-        select::select(phase_sub.next_message_pure(), ticker.next()).await;
+        ticker.next().await;
 
         let state = ossm.motion_state();
-
-        if let Some(prev) = &last_state {
-            if state.phase == prev.phase
-                && state.position == prev.position
-                && state.velocity == prev.velocity
-                && state.torque == prev.torque
-            {
-                continue;
-            }
-        }
-
-        last_state = Some(state);
 
         let telem = CoreTelemetry::from_state(&state, sequence);
         let mut payload = [0u8; CoreTelemetry::SIZE];


### PR DESCRIPTION
This is a proof of concept for a better development flow for hardware simulators.

## Problem

<!-- What issue does this solve? Link any relevant issues. -->The sim-m5stack doesn't work very well. The esp32 isn't powerful enough to drive the display, drive the motor, handle remotes and manage patterns all at the same time.

## Solution

Remove the need for dedicated sim hardware and run sims on target devices.

- Add telemetry to ossm (and keep the door open for other crates to emit their own telemetry)
- Hijack the uart to emit this telemetry
- Add a new page to the simulator webapp that connects to the uart, consumes the frames and drives the 3d animation.

## Testing

All of this runs locally.

1. Flash the waveshare board - it replaces the rs485 board with a sim board and motor.
2. Disconnect the uart from the espflash (ctrl+c after just flash-waveshare)
3. Run `just dev-patterns`to run the web app
4. Click the device mode button and connect, select the uart device
5. Connect a remote and start using the ossm. The sim should behave like a real ossm.

## Screenshots

![Screenshot 2026-03-25 at 09.25.09.png](https://app.graphite.com/user-attachments/assets/bd8a7f29-b6ed-4829-9369-930396d63e69.png)



<!-- If applicable, add screenshots or recordings. -->