### PR TITLE
feat(apps/web-tools): Adds web flasher

### DIFF
--- a/.github/workflows/deploy-webtools.yml
+++ b/.github/workflows/deploy-webtools.yml
@@ -89,7 +89,7 @@ jobs:
           workingDirectory: apps/web-tools
 
       - name: Update deployment status (success)
-        if: success() && github.actor != 'dependabot[bot]'
+        if: success() && steps.deployment.outputs.deployment_id
         uses: chrnorm/deployment-status@v2
         with:
           token: ${{ github.token }}
@@ -98,7 +98,7 @@ jobs:
           environment-url: ${{ steps.meta.outputs.url }}
 
       - name: Update deployment status (failure)
-        if: failure() && github.actor != 'dependabot[bot]'
+        if: failure() && steps.deployment.outputs.deployment_id
         uses: chrnorm/deployment-status@v2
         with:
           token: ${{ github.token }}

--- a/apps/web-tools/.gitignore
+++ b/apps/web-tools/.gitignore
@@ -1,2 +1,6 @@
 .vite
 node_modules
+
+dist
+*.tsbuildinfo
+.wrangler

--- a/apps/web-tools/index.html
+++ b/apps/web-tools/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>OSSM Simulator</title>
+    <title>OSSM Web Tools</title>
     <style>
       ::view-transition-old(root),
       ::view-transition-new(root) {

--- a/apps/web-tools/package.json
+++ b/apps/web-tools/package.json
@@ -17,21 +17,30 @@
     "@radix-ui/themes": "^3.3.0",
     "@react-three/drei": "^10.0.0",
     "@react-three/fiber": "^9.0.0",
+    "crypto-js": "^4.2.0",
+    "esptool-js": "^0.5.7",
+    "hono": "^4.12.9",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-router": "^7.13.2",
     "sim-wasm": "link:../../firmware/sim-wasm/pkg",
     "three": "^0.183.2"
   },
   "devDependencies": {
+    "@cloudflare/vite-plugin": "^1.30.1",
+    "@cloudflare/workers-types": "^4.20260317.1",
+    "@types/crypto-js": "^4.2.2",
     "@types/node": ">=24 <25",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.0.0",
     "@types/three": "^0.183.1",
+    "@types/w3c-web-serial": "^1.0.8",
     "@vitejs/plugin-react": "^5.2.0",
     "three-stdlib": "^2.36.1",
     "typescript": "~5.9.3",
     "vite": "^8.0.2",
     "vite-plugin-top-level-await": "^1.4.0",
-    "vite-plugin-wasm": "^3.6.0"
+    "vite-plugin-wasm": "^3.6.0",
+    "wrangler": "^4.77.0"
   }
 }

--- a/apps/web-tools/pnpm-lock.yaml
+++ b/apps/web-tools/pnpm-lock.yaml
@@ -20,12 +20,24 @@ importers:
       '@react-three/fiber':
         specifier: ^9.0.0
         version: 9.5.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(three@0.183.2)
+      crypto-js:
+        specifier: ^4.2.0
+        version: 4.2.0
+      esptool-js:
+        specifier: ^0.5.7
+        version: 0.5.7
+      hono:
+        specifier: ^4.12.9
+        version: 4.12.9
       react:
         specifier: ^19.0.0
         version: 19.2.4
       react-dom:
         specifier: ^19.0.0
         version: 19.2.4(react@19.2.4)
+      react-router:
+        specifier: ^7.13.2
+        version: 7.13.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       sim-wasm:
         specifier: link:../../firmware/sim-wasm/pkg
         version: link:../../firmware/sim-wasm/pkg
@@ -33,6 +45,15 @@ importers:
         specifier: ^0.183.2
         version: 0.183.2
     devDependencies:
+      '@cloudflare/vite-plugin':
+        specifier: ^1.30.1
+        version: 1.30.1(vite@8.0.2(@types/node@24.12.0)(esbuild@0.27.3)(tsx@4.21.0))(workerd@1.20260317.1)(wrangler@4.77.0(@cloudflare/workers-types@4.20260317.1))
+      '@cloudflare/workers-types':
+        specifier: ^4.20260317.1
+        version: 4.20260317.1
+      '@types/crypto-js':
+        specifier: ^4.2.2
+        version: 4.2.2
       '@types/node':
         specifier: '>=24 <25'
         version: 24.12.0
@@ -45,9 +66,12 @@ importers:
       '@types/three':
         specifier: ^0.183.1
         version: 0.183.1
+      '@types/w3c-web-serial':
+        specifier: ^1.0.8
+        version: 1.0.8
       '@vitejs/plugin-react':
         specifier: ^5.2.0
-        version: 5.2.0(vite@8.0.2(@types/node@24.12.0)(esbuild@0.27.3))
+        version: 5.2.0(vite@8.0.2(@types/node@24.12.0)(esbuild@0.27.3)(tsx@4.21.0))
       three-stdlib:
         specifier: ^2.36.1
         version: 2.36.1(three@0.183.2)
@@ -56,13 +80,16 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^8.0.2
-        version: 8.0.2(@types/node@24.12.0)(esbuild@0.27.3)
+        version: 8.0.2(@types/node@24.12.0)(esbuild@0.27.3)(tsx@4.21.0)
       vite-plugin-top-level-await:
         specifier: ^1.4.0
-        version: 1.6.0(rollup@4.59.0)(vite@8.0.2(@types/node@24.12.0)(esbuild@0.27.3))
+        version: 1.6.0(rollup@4.59.0)(vite@8.0.2(@types/node@24.12.0)(esbuild@0.27.3)(tsx@4.21.0))
       vite-plugin-wasm:
         specifier: ^3.6.0
-        version: 3.6.0(vite@8.0.2(@types/node@24.12.0)(esbuild@0.27.3))
+        version: 3.6.0(vite@8.0.2(@types/node@24.12.0)(esbuild@0.27.3)(tsx@4.21.0))
+      wrangler:
+        specifier: ^4.77.0
+        version: 4.77.0(@cloudflare/workers-types@4.20260317.1)
 
 packages:
 
@@ -152,6 +179,62 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@cloudflare/kv-asset-handler@0.4.2':
+    resolution: {integrity: sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@cloudflare/unenv-preset@2.16.0':
+    resolution: {integrity: sha512-8ovsRpwzPoEqPUzoErAYVv8l3FMZNeBVQfJTvtzP4AgLSRGZISRfuChFxHWUQd3n6cnrwkuTGxT+2cGo8EsyYg==}
+    peerDependencies:
+      unenv: 2.0.0-rc.24
+      workerd: 1.20260301.1 || ~1.20260302.1 || ~1.20260303.1 || ~1.20260304.1 || >1.20260305.0 <2.0.0-0
+    peerDependenciesMeta:
+      workerd:
+        optional: true
+
+  '@cloudflare/vite-plugin@1.30.1':
+    resolution: {integrity: sha512-gDWf2VJNRDp3ktWsTapx3gzffVfE2mkLiziiQOZGPgipvVBgWsCHO4UGqCDoLkXtB2gw4zgbGUKKqxBOn7WTSg==}
+    peerDependencies:
+      vite: ^6.1.0 || ^7.0.0 || ^8.0.0
+      wrangler: ^4.77.0
+
+  '@cloudflare/workerd-darwin-64@1.20260317.1':
+    resolution: {integrity: sha512-8hjh3sPMwY8M/zedq3/sXoA2Q4BedlGufn3KOOleIG+5a4ReQKLlUah140D7J6zlKmYZAFMJ4tWC7hCuI/s79g==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@cloudflare/workerd-darwin-arm64@1.20260317.1':
+    resolution: {integrity: sha512-M/MnNyvO5HMgoIdr3QHjdCj2T1ki9gt0vIUnxYxBu9ISXS/jgtMl6chUVPJ7zHYBn9MyYr8ByeN6frjYxj0MGg==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@cloudflare/workerd-linux-64@1.20260317.1':
+    resolution: {integrity: sha512-1ltuEjkRcS3fsVF7CxsKlWiRmzq2ZqMfqDN0qUOgbUwkpXsLVJsXmoblaLf5OP00ELlcgF0QsN0p2xPEua4Uug==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [linux]
+
+  '@cloudflare/workerd-linux-arm64@1.20260317.1':
+    resolution: {integrity: sha512-3QrNnPF1xlaNwkHpasvRvAMidOvQs2NhXQmALJrEfpIJ/IDL2la8g499yXp3eqhG3hVMCB07XVY149GTs42Xtw==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@cloudflare/workerd-windows-64@1.20260317.1':
+    resolution: {integrity: sha512-MfZTz+7LfuIpMGTa3RLXHX8Z/pnycZLItn94WRdHr8LPVet+C5/1Nzei399w/jr3+kzT4pDKk26JF/tlI5elpQ==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [win32]
+
+  '@cloudflare/workers-types@4.20260317.1':
+    resolution: {integrity: sha512-+G4eVwyCpm8Au1ex8vQBCuA9wnwqetz4tPNRoB/53qvktERWBRMQnrtvC1k584yRE3emMThtuY0gWshvSJ++PQ==}
+
+  '@cspotcode/source-map-support@0.8.1':
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    engines: {node: '>=12'}
 
   '@dimforge/rapier3d-compat@0.12.0':
     resolution: {integrity: sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==}
@@ -336,6 +419,159 @@ packages:
   '@floating-ui/utils@0.2.10':
     resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
 
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
+    engines: {node: '>=18'}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.34.5':
+    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linux-arm64@0.34.5':
+    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-arm@0.34.5':
+    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-s390x@0.34.5':
+    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-x64@0.34.5':
+    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-wasm32@0.34.5':
+    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [wasm32]
+
+  '@img/sharp-win32-arm64@0.34.5':
+    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-ia32@0.34.5':
+    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.34.5':
+    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [win32]
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -352,6 +588,9 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@jridgewell/trace-mapping@0.3.9':
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+
   '@mediapipe/tasks-vision@0.10.17':
     resolution: {integrity: sha512-CZWV/q6TTe8ta61cZXjfnnHsfWIdFhms03M9T7Cnd5y2mdpylJM0rF1qRq+wsQVRMLz1OYPVEBU9ph2Bx8cxrg==}
 
@@ -365,6 +604,15 @@ packages:
 
   '@oxc-project/types@0.122.0':
     resolution: {integrity: sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==}
+
+  '@poppinss/colors@4.1.6':
+    resolution: {integrity: sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==}
+
+  '@poppinss/dumper@0.6.5':
+    resolution: {integrity: sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==}
+
+  '@poppinss/exception@1.2.3':
+    resolution: {integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==}
 
   '@radix-ui/colors@3.0.0':
     resolution: {integrity: sha512-FUOsGBkHrYJwCSEtWRCIfQbZG7q1e6DgxCIOe1SUQzDe/7rXXeA47s8yCn6fuTNQAj1Zq4oTFi9Yjp3wzElcxg==}
@@ -1148,36 +1396,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.11':
     resolution: {integrity: sha512-jfndI9tsfm4APzjNt6QdBkYwre5lRPUgHeDHoI7ydKUuJvz3lZeCfMsI56BZj+7BYqiKsJm7cfd/6KYV7ubrBg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.11':
     resolution: {integrity: sha512-ZlFgw46NOAGMgcdvdYwAGu2Q+SLFA9LzbJLW+iyMOJyhj5wk6P3KEE9Gct4xWwSzFoPI7JCdYmYMzVtlgQ+zfw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.11':
     resolution: {integrity: sha512-hIOYmuT6ofM4K04XAZd3OzMySEO4K0/nc9+jmNcxNAxRi6c5UWpqfw3KMFV4MVFWL+jQsSh+bGw2VqmaPMTLyw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.11':
     resolution: {integrity: sha512-qXBQQO9OvkjjQPLdUVr7Nr2t3QTZI7s4KZtfw7HzBgjbmAPSFwSv4rmET9lLSgq3rH/ndA3ngv3Qb8l2njoPNA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.11':
     resolution: {integrity: sha512-/tpFfoSTzUkH9LPY+cYbqZBDyyX62w5fICq9qzsHLL8uTI6BHip3Q9Uzft0wylk/i8OOwKik8OxW+QAhDmzwmg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.11':
     resolution: {integrity: sha512-mcp3Rio2w72IvdZG0oQ4bM2c2oumtwHfUfKncUM6zGgz0KgPz4YmDPQfnXEiY5t3+KD/i8HG2rOB/LxdmieK2g==}
@@ -1251,66 +1505,79 @@ packages:
     resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.59.0':
     resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.59.0':
     resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.59.0':
     resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.59.0':
     resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.59.0':
     resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.59.0':
     resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.59.0':
     resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.59.0':
     resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.59.0':
     resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.59.0':
     resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.59.0':
     resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.59.0':
     resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.59.0':
     resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
@@ -1342,6 +1609,13 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@sindresorhus/is@7.2.0':
+    resolution: {integrity: sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==}
+    engines: {node: '>=18'}
+
+  '@speed-highlight/core@1.2.15':
+    resolution: {integrity: sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==}
+
   '@swc/core-darwin-arm64@1.15.18':
     resolution: {integrity: sha512-+mIv7uBuSaywN3C9LNuWaX1jJJ3SKfiJuE6Lr3bd+/1Iv8oMU7oLBjYMluX1UrEPzwN2qCdY6Io0yVicABoCwQ==}
     engines: {node: '>=10'}
@@ -1365,24 +1639,28 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.15.18':
     resolution: {integrity: sha512-0a+Lix+FSSHBSBOA0XznCcHo5/1nA6oLLjcnocvzXeqtdjnPb+SvchItHI+lfeiuj1sClYPDvPMLSLyXFaiIKw==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.15.18':
     resolution: {integrity: sha512-wG9J8vReUlpaHz4KOD/5UE1AUgirimU4UFT9oZmupUDEofxJKYb1mTA/DrMj0s78bkBiNI+7Fo2EgPuvOJfuAA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.15.18':
     resolution: {integrity: sha512-4nwbVvCphKzicwNWRmvD5iBaZj8JYsRGa4xOxJmOyHlMDpsvvJ2OR2cODlvWyGFH6BYL1MfIAK3qph3hp0Az6g==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.15.18':
     resolution: {integrity: sha512-zk0RYO+LjiBCat2RTMHzAWaMky0cra9loH4oRrLKLLNuL+jarxKLFDA8xTZWEkCPLjUTwlRN7d28eDLLMgtUcQ==}
@@ -1438,6 +1716,9 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/crypto-js@4.2.2':
+    resolution: {integrity: sha512-sDOLlVbHhXpAUAL0YHDUUwDZf3iN4Bwi4W6a0W0b+QcAezUbRtH4FVb+9J4h+XFPW7l/gQ9F8qC7P+Ec4k8QVQ==}
+
   '@types/draco3d@1.4.10':
     resolution: {integrity: sha512-AX22jp8Y7wwaBgAixaSvkoG4M/+PlAcm3Qs4OW8yT9DM4xUpWKeFhLueTAyZF39pviAdcDdeJoACapiAceqNcw==}
 
@@ -1469,6 +1750,9 @@ packages:
   '@types/three@0.183.1':
     resolution: {integrity: sha512-f2Pu5Hrepfgavttdye3PsH5RWyY/AvdZQwIVhrc4uNtvF7nOWJacQKcoVJn0S4f0yYbmAE6AR+ve7xDcuYtMGw==}
 
+  '@types/w3c-web-serial@1.0.8':
+    resolution: {integrity: sha512-QQOT+bxQJhRGXoZDZGLs3ksLud1dMNnMiSQtBA0w8KXvLpXX4oM4TZb6J0GgJ8UbCaHo5s9/4VQT8uXy9JER2A==}
+
   '@types/webxr@0.5.24':
     resolution: {integrity: sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==}
 
@@ -1493,6 +1777,9 @@ packages:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
 
+  atob-lite@2.0.0:
+    resolution: {integrity: sha512-LEeSAWeh2Gfa2FtlQE1shxQ8zi5F9GHarrGKz08TMdODD5T4eH6BMsvtnhbWZ+XQn+Gb6om/917ucvRu7l7ukw==}
+
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -1503,6 +1790,9 @@ packages:
 
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
+  blake3-wasm@2.1.5:
+    resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
 
   browserslist@4.28.1:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
@@ -1527,6 +1817,10 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
+
   cross-env@7.0.3:
     resolution: {integrity: sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==}
     engines: {node: '>=10.14', npm: '>=6', yarn: '>=1'}
@@ -1535,6 +1829,9 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  crypto-js@4.2.0:
+    resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
@@ -1564,6 +1861,9 @@ packages:
   electron-to-chromium@1.5.302:
     resolution: {integrity: sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==}
 
+  error-stack-parser-es@1.0.5:
+    resolution: {integrity: sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==}
+
   esbuild@0.27.3:
     resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
     engines: {node: '>=18'}
@@ -1572,6 +1872,9 @@ packages:
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
+
+  esptool-js@0.5.7:
+    resolution: {integrity: sha512-k3pkXU9OTySCd58OUDjuJWNnFjM+QpPWAghxyWPm3zNfaLiP4ex2jNd7Rj0jWPu3/fgvwau236tetsTZrh4x5g==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -1601,11 +1904,18 @@ packages:
     resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
     engines: {node: '>=6'}
 
+  get-tsconfig@4.13.7:
+    resolution: {integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==}
+
   glsl-noise@0.0.0:
     resolution: {integrity: sha512-b/ZCF6amfAUb7dJM/MxRs7AetQEahYzJ8PtgfrmEdtw6uyGOr+ZSGtgjFm6mfsBkxJ4d2W7kg+Nlqzqvn3Bc0w==}
 
   hls.js@1.6.15:
     resolution: {integrity: sha512-E3a5VwgXimGHwpRGV+WxRTKeSp2DW5DI5MWv34ulL3t5UNmyJWCQ1KmLEHbYzcfThfXG8amBL+fCYPneGHC4VA==}
+
+  hono@4.12.9:
+    resolution: {integrity: sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==}
+    engines: {node: '>=16.9.0'}
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -1636,6 +1946,10 @@ packages:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  kleur@4.1.5:
+    resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
+    engines: {node: '>=6'}
 
   lie@3.3.0:
     resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
@@ -1675,24 +1989,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -1727,6 +2045,11 @@ packages:
   meshoptimizer@1.0.1:
     resolution: {integrity: sha512-Vix+QlA1YYT3FwmBBZ+49cE5y/b+pRrcXKqGpS5ouh33d3lSp2PoTpCw19E0cKDFWalembrHnIaZetf27a+W2g==}
 
+  miniflare@4.20260317.2:
+    resolution: {integrity: sha512-qNL+yWAFMX6fr0pWU6Lx1vNpPobpnDSF1V8eunIckWvoIQl8y1oBjL2RJFEGY3un+l3f9gwW9dirDPP26usYJQ==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -1738,9 +2061,18 @@ packages:
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
 
+  pako@2.1.0:
+    resolution: {integrity: sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==}
+
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  path-to-regexp@6.3.0:
+    resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -1801,6 +2133,16 @@ packages:
       '@types/react':
         optional: true
 
+  react-router@7.13.2:
+    resolution: {integrity: sha512-tX1Aee+ArlKQP+NIUd7SE6Li+CiGKwQtbS+FfRxPX6Pe4vHOo6nr9d++u5cwg+Z8K/x8tP+7qLmujDtfrAoUJA==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+
   react-style-singleton@2.2.3:
     resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
     engines: {node: '>=10'}
@@ -1828,6 +2170,9 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
   rolldown@1.0.0-rc.11:
     resolution: {integrity: sha512-NRjoKMusSjfRbSYiH3VSumlkgFe7kYAa3pzVOsVYVFY3zb5d7nS+a3KGQ7hJKXuYWbzJKPVQ9Wxq2UvyK+ENpw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1844,6 +2189,18 @@ packages:
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
+
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  set-cookie-parser@2.7.2:
+    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
+
+  sharp@0.34.5:
+    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -1865,6 +2222,10 @@ packages:
 
   stats.js@0.17.0:
     resolution: {integrity: sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw==}
+
+  supports-color@10.2.2:
+    resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
+    engines: {node: '>=18'}
 
   suspend-react@0.1.3:
     resolution: {integrity: sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ==}
@@ -1904,6 +2265,11 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   tunnel-rat@0.1.2:
     resolution: {integrity: sha512-lR5VHmkPhzdhrM092lI2nACsLO4QubF0/yoOhzX7c+wIpbN1GjHNzCc91QlpxBi+cnx8vVJ+Ur6vL5cEoQPFpQ==}
 
@@ -1914,6 +2280,13 @@ packages:
 
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
+  undici@7.24.4:
+    resolution: {integrity: sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==}
+    engines: {node: '>=20.18.1'}
+
+  unenv@2.0.0-rc.24:
+    resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
 
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
@@ -2018,8 +2391,41 @@ packages:
     engines: {node: '>= 8'}
     hasBin: true
 
+  workerd@1.20260317.1:
+    resolution: {integrity: sha512-ZuEq1OdrJBS+NV+L5HMYPCzVn49a2O60slQiiLpG44jqtlOo+S167fWC76kEXteXLLLydeuRrluRel7WdOUa4g==}
+    engines: {node: '>=16'}
+    hasBin: true
+
+  wrangler@4.77.0:
+    resolution: {integrity: sha512-E2Gm69+K++BFd3QvoWjC290RPQj1vDOUotA++sNHmtKPb7EP6C8Qv+1D5Ii73tfZtyNgakpqHlh8lBBbVWTKAQ==}
+    engines: {node: '>=20.3.0'}
+    hasBin: true
+    peerDependencies:
+      '@cloudflare/workers-types': ^4.20260317.1
+    peerDependenciesMeta:
+      '@cloudflare/workers-types':
+        optional: true
+
+  ws@8.18.0:
+    resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  youch-core@0.3.3:
+    resolution: {integrity: sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==}
+
+  youch@4.1.0-beta.10:
+    resolution: {integrity: sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==}
 
   zustand@4.5.7:
     resolution: {integrity: sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==}
@@ -2170,6 +2576,48 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
+  '@cloudflare/kv-asset-handler@0.4.2': {}
+
+  '@cloudflare/unenv-preset@2.16.0(unenv@2.0.0-rc.24)(workerd@1.20260317.1)':
+    dependencies:
+      unenv: 2.0.0-rc.24
+    optionalDependencies:
+      workerd: 1.20260317.1
+
+  '@cloudflare/vite-plugin@1.30.1(vite@8.0.2(@types/node@24.12.0)(esbuild@0.27.3)(tsx@4.21.0))(workerd@1.20260317.1)(wrangler@4.77.0(@cloudflare/workers-types@4.20260317.1))':
+    dependencies:
+      '@cloudflare/unenv-preset': 2.16.0(unenv@2.0.0-rc.24)(workerd@1.20260317.1)
+      miniflare: 4.20260317.2
+      unenv: 2.0.0-rc.24
+      vite: 8.0.2(@types/node@24.12.0)(esbuild@0.27.3)(tsx@4.21.0)
+      wrangler: 4.77.0(@cloudflare/workers-types@4.20260317.1)
+      ws: 8.18.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - workerd
+
+  '@cloudflare/workerd-darwin-64@1.20260317.1':
+    optional: true
+
+  '@cloudflare/workerd-darwin-arm64@1.20260317.1':
+    optional: true
+
+  '@cloudflare/workerd-linux-64@1.20260317.1':
+    optional: true
+
+  '@cloudflare/workerd-linux-arm64@1.20260317.1':
+    optional: true
+
+  '@cloudflare/workerd-windows-64@1.20260317.1':
+    optional: true
+
+  '@cloudflare/workers-types@4.20260317.1': {}
+
+  '@cspotcode/source-map-support@0.8.1':
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.9
+
   '@dimforge/rapier3d-compat@0.12.0': {}
 
   '@emnapi/core@1.9.1':
@@ -2283,6 +2731,102 @@ snapshots:
 
   '@floating-ui/utils@0.2.10': {}
 
+  '@img/colour@1.1.0': {}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-darwin-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-arm@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-s390x@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-wasm32@0.34.5':
+    dependencies:
+      '@emnapi/runtime': 1.9.1
+    optional: true
+
+  '@img/sharp-win32-arm64@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-ia32@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.34.5':
+    optional: true
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -2302,6 +2846,11 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@jridgewell/trace-mapping@0.3.9':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   '@mediapipe/tasks-vision@0.10.17': {}
 
   '@monogrid/gainmap-js@3.4.0(three@0.183.2)':
@@ -2317,6 +2866,18 @@ snapshots:
     optional: true
 
   '@oxc-project/types@0.122.0': {}
+
+  '@poppinss/colors@4.1.6':
+    dependencies:
+      kleur: 4.1.5
+
+  '@poppinss/dumper@0.6.5':
+    dependencies:
+      '@poppinss/colors': 4.1.6
+      '@sindresorhus/is': 7.2.0
+      supports-color: 10.2.2
+
+  '@poppinss/exception@1.2.3': {}
 
   '@radix-ui/colors@3.0.0': {}
 
@@ -3266,6 +3827,10 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.59.0':
     optional: true
 
+  '@sindresorhus/is@7.2.0': {}
+
+  '@speed-highlight/core@1.2.15': {}
+
   '@swc/core-darwin-arm64@1.15.18':
     optional: true
 
@@ -3348,6 +3913,8 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
+  '@types/crypto-js@4.2.2': {}
+
   '@types/draco3d@1.4.10': {}
 
   '@types/estree@1.0.8':
@@ -3383,6 +3950,8 @@ snapshots:
       fflate: 0.8.2
       meshoptimizer: 1.0.1
 
+  '@types/w3c-web-serial@1.0.8': {}
+
   '@types/webxr@0.5.24': {}
 
   '@use-gesture/core@10.3.1': {}
@@ -3392,7 +3961,7 @@ snapshots:
       '@use-gesture/core': 10.3.1
       react: 19.2.4
 
-  '@vitejs/plugin-react@5.2.0(vite@8.0.2(@types/node@24.12.0)(esbuild@0.27.3))':
+  '@vitejs/plugin-react@5.2.0(vite@8.0.2(@types/node@24.12.0)(esbuild@0.27.3)(tsx@4.21.0))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -3400,7 +3969,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.3
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
-      vite: 8.0.2(@types/node@24.12.0)(esbuild@0.27.3)
+      vite: 8.0.2(@types/node@24.12.0)(esbuild@0.27.3)(tsx@4.21.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -3410,6 +3979,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  atob-lite@2.0.0: {}
+
   base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.10.0: {}
@@ -3417,6 +3988,8 @@ snapshots:
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
+
+  blake3-wasm@2.1.5: {}
 
   browserslist@4.28.1:
     dependencies:
@@ -3441,6 +4014,8 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  cookie@1.1.1: {}
+
   cross-env@7.0.3:
     dependencies:
       cross-spawn: 7.0.6
@@ -3450,6 +4025,8 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  crypto-js@4.2.0: {}
 
   csstype@3.2.3: {}
 
@@ -3468,6 +4045,8 @@ snapshots:
   draco3d@1.5.7: {}
 
   electron-to-chromium@1.5.302: {}
+
+  error-stack-parser-es@1.0.5: {}
 
   esbuild@0.27.3:
     optionalDependencies:
@@ -3497,9 +4076,14 @@ snapshots:
       '@esbuild/win32-arm64': 0.27.3
       '@esbuild/win32-ia32': 0.27.3
       '@esbuild/win32-x64': 0.27.3
-    optional: true
 
   escalade@3.2.0: {}
+
+  esptool-js@0.5.7:
+    dependencies:
+      atob-lite: 2.0.0
+      pako: 2.1.0
+      tslib: 2.8.1
 
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
@@ -3516,9 +4100,16 @@ snapshots:
 
   get-nonce@1.0.1: {}
 
+  get-tsconfig@4.13.7:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+    optional: true
+
   glsl-noise@0.0.0: {}
 
   hls.js@1.6.15: {}
+
+  hono@4.12.9: {}
 
   ieee754@1.2.1: {}
 
@@ -3540,6 +4131,8 @@ snapshots:
   jsesc@3.1.0: {}
 
   json5@2.2.3: {}
+
+  kleur@4.1.5: {}
 
   lie@3.3.0:
     dependencies:
@@ -3609,13 +4202,31 @@ snapshots:
 
   meshoptimizer@1.0.1: {}
 
+  miniflare@4.20260317.2:
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      sharp: 0.34.5
+      undici: 7.24.4
+      workerd: 1.20260317.1
+      ws: 8.18.0
+      youch: 4.1.0-beta.10
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   ms@2.1.3: {}
 
   nanoid@3.3.11: {}
 
   node-releases@2.0.27: {}
 
+  pako@2.1.0: {}
+
   path-key@3.1.1: {}
+
+  path-to-regexp@6.3.0: {}
+
+  pathe@2.0.3: {}
 
   picocolors@1.1.1: {}
 
@@ -3723,6 +4334,14 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  react-router@7.13.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      cookie: 1.1.1
+      react: 19.2.4
+      set-cookie-parser: 2.7.2
+    optionalDependencies:
+      react-dom: 19.2.4(react@19.2.4)
+
   react-style-singleton@2.2.3(@types/react@19.2.14)(react@19.2.4):
     dependencies:
       get-nonce: 1.0.1
@@ -3740,6 +4359,9 @@ snapshots:
   react@19.2.4: {}
 
   require-from-string@2.0.2: {}
+
+  resolve-pkg-maps@1.0.0:
+    optional: true
 
   rolldown@1.0.0-rc.11:
     dependencies:
@@ -3798,6 +4420,41 @@ snapshots:
 
   semver@6.3.1: {}
 
+  semver@7.7.4: {}
+
+  set-cookie-parser@2.7.2: {}
+
+  sharp@0.34.5:
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.7.4
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.34.5
+      '@img/sharp-darwin-x64': 0.34.5
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+      '@img/sharp-libvips-linux-arm': 1.2.4
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+      '@img/sharp-libvips-linux-x64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+      '@img/sharp-linux-arm': 0.34.5
+      '@img/sharp-linux-arm64': 0.34.5
+      '@img/sharp-linux-ppc64': 0.34.5
+      '@img/sharp-linux-riscv64': 0.34.5
+      '@img/sharp-linux-s390x': 0.34.5
+      '@img/sharp-linux-x64': 0.34.5
+      '@img/sharp-linuxmusl-arm64': 0.34.5
+      '@img/sharp-linuxmusl-x64': 0.34.5
+      '@img/sharp-wasm32': 0.34.5
+      '@img/sharp-win32-arm64': 0.34.5
+      '@img/sharp-win32-ia32': 0.34.5
+      '@img/sharp-win32-x64': 0.34.5
+
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
@@ -3812,6 +4469,8 @@ snapshots:
       three: 0.183.2
 
   stats.js@0.17.0: {}
+
+  supports-color@10.2.2: {}
 
   suspend-react@0.1.3(react@19.2.4):
     dependencies:
@@ -3854,6 +4513,14 @@ snapshots:
 
   tslib@2.8.1: {}
 
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.3
+      get-tsconfig: 4.13.7
+    optionalDependencies:
+      fsevents: 2.3.3
+    optional: true
+
   tunnel-rat@0.1.2(@types/react@19.2.14)(react@19.2.4):
     dependencies:
       zustand: 4.5.7(@types/react@19.2.14)(react@19.2.4)
@@ -3865,6 +4532,12 @@ snapshots:
   typescript@5.9.3: {}
 
   undici-types@7.16.0: {}
+
+  undici@7.24.4: {}
+
+  unenv@2.0.0-rc.24:
+    dependencies:
+      pathe: 2.0.3
 
   update-browserslist-db@1.2.3(browserslist@4.28.1):
     dependencies:
@@ -3895,22 +4568,22 @@ snapshots:
 
   uuid@10.0.0: {}
 
-  vite-plugin-top-level-await@1.6.0(rollup@4.59.0)(vite@8.0.2(@types/node@24.12.0)(esbuild@0.27.3)):
+  vite-plugin-top-level-await@1.6.0(rollup@4.59.0)(vite@8.0.2(@types/node@24.12.0)(esbuild@0.27.3)(tsx@4.21.0)):
     dependencies:
       '@rollup/plugin-virtual': 3.0.2(rollup@4.59.0)
       '@swc/core': 1.15.18
       '@swc/wasm': 1.15.18
       uuid: 10.0.0
-      vite: 8.0.2(@types/node@24.12.0)(esbuild@0.27.3)
+      vite: 8.0.2(@types/node@24.12.0)(esbuild@0.27.3)(tsx@4.21.0)
     transitivePeerDependencies:
       - '@swc/helpers'
       - rollup
 
-  vite-plugin-wasm@3.6.0(vite@8.0.2(@types/node@24.12.0)(esbuild@0.27.3)):
+  vite-plugin-wasm@3.6.0(vite@8.0.2(@types/node@24.12.0)(esbuild@0.27.3)(tsx@4.21.0)):
     dependencies:
-      vite: 8.0.2(@types/node@24.12.0)(esbuild@0.27.3)
+      vite: 8.0.2(@types/node@24.12.0)(esbuild@0.27.3)(tsx@4.21.0)
 
-  vite@8.0.2(@types/node@24.12.0)(esbuild@0.27.3):
+  vite@8.0.2(@types/node@24.12.0)(esbuild@0.27.3)(tsx@4.21.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.3
@@ -3921,6 +4594,7 @@ snapshots:
       '@types/node': 24.12.0
       esbuild: 0.27.3
       fsevents: 2.3.3
+      tsx: 4.21.0
 
   webgl-constants@1.1.1: {}
 
@@ -3930,7 +4604,47 @@ snapshots:
     dependencies:
       isexe: 2.0.0
 
+  workerd@1.20260317.1:
+    optionalDependencies:
+      '@cloudflare/workerd-darwin-64': 1.20260317.1
+      '@cloudflare/workerd-darwin-arm64': 1.20260317.1
+      '@cloudflare/workerd-linux-64': 1.20260317.1
+      '@cloudflare/workerd-linux-arm64': 1.20260317.1
+      '@cloudflare/workerd-windows-64': 1.20260317.1
+
+  wrangler@4.77.0(@cloudflare/workers-types@4.20260317.1):
+    dependencies:
+      '@cloudflare/kv-asset-handler': 0.4.2
+      '@cloudflare/unenv-preset': 2.16.0(unenv@2.0.0-rc.24)(workerd@1.20260317.1)
+      blake3-wasm: 2.1.5
+      esbuild: 0.27.3
+      miniflare: 4.20260317.2
+      path-to-regexp: 6.3.0
+      unenv: 2.0.0-rc.24
+      workerd: 1.20260317.1
+    optionalDependencies:
+      '@cloudflare/workers-types': 4.20260317.1
+      fsevents: 2.3.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  ws@8.18.0: {}
+
   yallist@3.1.1: {}
+
+  youch-core@0.3.3:
+    dependencies:
+      '@poppinss/exception': 1.2.3
+      error-stack-parser-es: 1.0.5
+
+  youch@4.1.0-beta.10:
+    dependencies:
+      '@poppinss/colors': 4.1.6
+      '@poppinss/dumper': 0.6.5
+      '@speed-highlight/core': 1.2.15
+      cookie: 1.1.1
+      youch-core: 0.3.3
 
   zustand@4.5.7(@types/react@19.2.14)(react@19.2.4):
     dependencies:

--- a/apps/web-tools/pnpm-workspace.yaml
+++ b/apps/web-tools/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
 onlyBuiltDependencies:
   - '@swc/core'
   - esbuild
+  - sharp
+  - workerd

--- a/apps/web-tools/src/Layout.tsx
+++ b/apps/web-tools/src/Layout.tsx
@@ -1,0 +1,79 @@
+import { NavLink, Outlet } from "react-router";
+import { useAppearance } from "./hooks/useAppearance";
+import {
+  Theme,
+  Flex,
+  TabNav,
+  IconButton,
+  Button,
+  Tooltip,
+  Text,
+} from "@radix-ui/themes";
+import { SunIcon, MoonIcon, GitHubLogoIcon } from "@radix-ui/react-icons";
+
+export default function Layout() {
+  const [appearance, toggleAppearance] = useAppearance();
+
+  return (
+    <Theme accentColor="purple" radius="large" appearance={appearance}>
+      <Flex direction="column" height="100vh">
+        <Flex
+          align="center"
+          justify="between"
+          px="4"
+          style={{ borderBottom: "1px solid var(--gray-5)" }}
+        >
+          <Flex align="center" gap="4">
+            <Text size="3" weight="bold">
+              ossm-rs
+            </Text>
+            <TabNav.Root>
+              <NavLink to="/" end>
+                {({ isActive }) => (
+                  <TabNav.Link asChild active={isActive}>
+                    <span>Simulator</span>
+                  </TabNav.Link>
+                )}
+              </NavLink>
+              <NavLink to="/flasher">
+                {({ isActive }) => (
+                  <TabNav.Link asChild active={isActive}>
+                    <span>Flasher</span>
+                  </TabNav.Link>
+                )}
+              </NavLink>
+            </TabNav.Root>
+          </Flex>
+          <Flex align="center" gap="2">
+            <Button variant="soft" size="2" asChild>
+              <a
+                href="https://github.com/ossm-rs/ossm"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <GitHubLogoIcon /> ossm-rs/ossm
+              </a>
+            </Button>
+            <Tooltip
+              content={
+                appearance === "light"
+                  ? "Switch to dark mode"
+                  : "Switch to light mode"
+              }
+            >
+              <IconButton
+                variant="soft"
+                size="2"
+                onClick={toggleAppearance}
+                aria-label="Toggle theme"
+              >
+                {appearance === "light" ? <SunIcon /> : <MoonIcon />}
+              </IconButton>
+            </Tooltip>
+          </Flex>
+        </Flex>
+        <Outlet />
+      </Flex>
+    </Theme>
+  );
+}

--- a/apps/web-tools/src/api/github-asset.ts
+++ b/apps/web-tools/src/api/github-asset.ts
@@ -1,0 +1,26 @@
+export async function handleGithubAsset(id: string): Promise<Response> {
+  const upstream = await fetch(
+    `https://api.github.com/repos/ossm-rs/ossm/releases/assets/${id}`,
+    {
+      headers: {
+        Accept: "application/octet-stream",
+        "User-Agent": "ossm-web-tools",
+      },
+      redirect: "follow",
+    },
+  );
+
+  if (!upstream.ok) {
+    return Response.json(
+      { error: `GitHub returned ${upstream.status}` },
+      { status: upstream.status },
+    );
+  }
+
+  return new Response(upstream.body, {
+    headers: {
+      "Content-Type": "application/octet-stream",
+      "Cache-Control": "public, max-age=3600",
+    },
+  });
+}

--- a/apps/web-tools/src/api/index.ts
+++ b/apps/web-tools/src/api/index.ts
@@ -1,0 +1,18 @@
+import { Hono } from "hono";
+import { handleGithubAsset } from "./github-asset";
+
+interface Env {
+  ASSETS: Fetcher;
+}
+
+const app = new Hono<{ Bindings: Env }>();
+
+app.get("/api/github-asset/:id{\\d+}", (c) => {
+  return handleGithubAsset(c.req.param("id"));
+});
+
+app.all("*", (c) => {
+  return c.env.ASSETS.fetch(c.req.raw);
+});
+
+export default app;

--- a/apps/web-tools/src/api/tsconfig.json
+++ b/apps/web-tools/src/api/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "types": ["@cloudflare/workers-types"]
+  },
+  "include": ["."]
+}

--- a/apps/web-tools/src/global.css
+++ b/apps/web-tools/src/global.css
@@ -1,0 +1,3 @@
+body {
+  margin: 0;
+}

--- a/apps/web-tools/src/hooks/useGithubReleases.ts
+++ b/apps/web-tools/src/hooks/useGithubReleases.ts
@@ -1,0 +1,59 @@
+import { useState, useEffect } from "react";
+
+export interface ReleaseAsset {
+  id: number;
+  name: string;
+  browser_download_url: string;
+  size: number;
+}
+
+export interface Release {
+  tag_name: string;
+  name: string;
+  published_at: string;
+  assets: ReleaseAsset[];
+}
+
+const RELEASES_URL = "https://api.github.com/repos/ossm-rs/ossm/releases";
+
+export function useGithubReleases() {
+  const [releases, setReleases] = useState<Release[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function fetchReleases() {
+      try {
+        const response = await fetch(RELEASES_URL);
+        if (!response.ok) {
+          throw new Error(`GitHub API returned ${response.status}`);
+        }
+        const data: Release[] = await response.json();
+        if (!cancelled) {
+          // Only include releases that have .bin assets
+          const withBinaries = data.filter((r) =>
+            r.assets.some((a) => a.name.endsWith(".bin")),
+          );
+          setReleases(withBinaries);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : "Failed to fetch releases");
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
+
+    fetchReleases();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return { releases, loading, error };
+}

--- a/apps/web-tools/src/main.tsx
+++ b/apps/web-tools/src/main.tsx
@@ -1,13 +1,24 @@
 import { createRoot } from "react-dom/client";
+import { BrowserRouter, Routes, Route } from "react-router";
 import "@radix-ui/themes/styles.css";
+import "./global.css";
 import { AppearanceProvider } from "./AppearanceProvider";
 import { SimulatorProvider } from "./SimulatorProvider";
-import App from "./App";
+import Layout from "./Layout";
+import FlasherPage from "./pages/FlasherPage";
+import SimulatorPage from "./pages/SimulatorPage";
 
 createRoot(document.getElementById("root")!).render(
-  <AppearanceProvider>
-    <SimulatorProvider fallback={<p>Loading simulator…</p>}>
-      <App />
-    </SimulatorProvider>
-  </AppearanceProvider>,
+  <BrowserRouter>
+    <AppearanceProvider>
+      <SimulatorProvider fallback={<p>Loading simulator…</p>}>
+        <Routes>
+          <Route element={<Layout />}>
+            <Route index element={<SimulatorPage />} />
+            <Route path="flasher" element={<FlasherPage />} />
+          </Route>
+        </Routes>
+      </SimulatorProvider>
+    </AppearanceProvider>
+  </BrowserRouter>,
 );

--- a/apps/web-tools/src/pages/FlasherPage.tsx
+++ b/apps/web-tools/src/pages/FlasherPage.tsx
@@ -1,0 +1,379 @@
+import { useState, useCallback, useRef, useMemo, useEffect } from "react";
+import { ESPLoader, Transport } from "esptool-js";
+import CryptoJS from "crypto-js";
+import {
+  Box,
+  Card,
+  Flex,
+  Heading,
+  Text,
+  Select,
+  Button,
+  Callout,
+  Separator,
+  Progress,
+  ScrollArea,
+  Code,
+} from "@radix-ui/themes";
+import {
+  InfoCircledIcon,
+  ExclamationTriangleIcon,
+} from "@radix-ui/react-icons";
+import { useGithubReleases } from "../hooks/useGithubReleases";
+
+const BAUD = 921600;
+
+// Friendly labels for known firmware binaries; anything else falls back to the filename
+const BOARD_LABELS: Record<string, string> = {
+  "ossm-alt": "OSSM Alt",
+  waveshare: "Waveshare ESP32-S3-RS485-CAN",
+};
+
+type FlashState =
+  | "idle"
+  | "connecting"
+  | "connected"
+  | "flashing"
+  | "done"
+  | "error";
+
+export default function FlasherPage() {
+  const {
+    releases,
+    loading: releasesLoading,
+    error: releasesError,
+  } = useGithubReleases();
+  const [selectedRelease, setSelectedRelease] = useState<string>("");
+  const [selectedBoard, setSelectedBoard] = useState<string>("");
+  const [flashState, setFlashState] = useState<FlashState>("idle");
+  const [progress, setProgress] = useState(0);
+  const [logs, setLogs] = useState<string[]>([]);
+  const logEndRef = useRef<HTMLDivElement>(null);
+
+  const transportRef = useRef<Transport | null>(null);
+  const espLoaderRef = useRef<ESPLoader | null>(null);
+  const deviceRef = useRef<SerialPort | null>(null);
+
+  const webSerialSupported =
+    typeof navigator !== "undefined" && "serial" in navigator;
+
+  useEffect(() => {
+    return () => {
+      transportRef.current?.disconnect().catch(() => {});
+    };
+  }, []);
+
+  // Derive available boards from the selected release's .bin assets
+  const boards = useMemo(() => {
+    const release = releases.find((r) => r.tag_name === selectedRelease);
+    if (!release) return [];
+    return release.assets
+      .filter((a) => a.name.endsWith(".bin"))
+      .map((a) => {
+        const stem = a.name.replace(/\.bin$/, "");
+        return {
+          value: a.name,
+          label: BOARD_LABELS[stem] ?? a.name,
+          asset: a,
+        };
+      });
+  }, [releases, selectedRelease]);
+
+  const appendLog = useCallback((line: string) => {
+    setLogs((prev) => [...prev, line]);
+    // Auto-scroll on next frame
+    requestAnimationFrame(() => {
+      logEndRef.current?.scrollIntoView({ behavior: "smooth" });
+    });
+  }, []);
+
+  const espLoaderTerminal = useRef({
+    clean() {},
+    writeLine(_data: string) {},
+    write(_data: string) {},
+  }).current;
+
+  const handleConnect = useCallback(async () => {
+    if (flashState === "connected" || flashState === "connecting") {
+      // Disconnect
+      if (transportRef.current) {
+        await transportRef.current.disconnect();
+      }
+      transportRef.current = null;
+      espLoaderRef.current = null;
+      deviceRef.current = null;
+      setFlashState("idle");
+      setLogs([]);
+      return;
+    }
+
+    try {
+      setFlashState("connecting");
+      appendLog("Requesting serial port...");
+
+      const device = await navigator.serial.requestPort();
+      deviceRef.current = device;
+
+      const transport = new Transport(device);
+      transportRef.current = transport;
+
+      const espLoader = new ESPLoader({
+        transport,
+        baudrate: BAUD,
+        romBaudrate: 115200,
+        terminal: espLoaderTerminal,
+      });
+      espLoaderRef.current = espLoader;
+
+      const chip = await espLoader.main();
+      appendLog(`Connected to ${chip}`);
+      setFlashState("connected");
+    } catch (err) {
+      appendLog(
+        `Connection failed: ${err instanceof Error ? err.message : err}`,
+      );
+      setFlashState("error");
+    }
+  }, [flashState, appendLog, espLoaderTerminal]);
+
+  const handleFlash = useCallback(async () => {
+    const espLoader = espLoaderRef.current;
+    if (!espLoader || !selectedBoard) return;
+
+    const board = boards.find((b) => b.value === selectedBoard);
+    if (!board) {
+      appendLog(`No binary selected`);
+      setFlashState("error");
+      return;
+    }
+
+    const asset = board.asset;
+
+    try {
+      setFlashState("flashing");
+      setProgress(0);
+
+      appendLog(`Downloading ${asset.name} (${formatBytes(asset.size)})...`);
+      const response = await fetch(`/api/github-asset/${asset.id}`);
+      if (!response.ok) {
+        throw new Error(`Download failed: ${response.status}`);
+      }
+      const arrayBuffer = await response.arrayBuffer();
+      const binaryStr = Array.from(new Uint8Array(arrayBuffer), (byte) =>
+        String.fromCharCode(byte),
+      ).join("");
+      appendLog(`Downloaded ${arrayBuffer.byteLength} bytes`);
+
+      appendLog("Flashing...");
+      await espLoader.writeFlash({
+        fileArray: [{ data: binaryStr, address: 0 }],
+        flashSize: "keep",
+        flashMode: "keep",
+        flashFreq: "keep",
+        eraseAll: false,
+        compress: true,
+        reportProgress: (
+          _fileIndex: number,
+          written: number,
+          total: number,
+        ) => {
+          setProgress(Math.round((written / total) * 100));
+        },
+        calculateMD5Hash: (image: string) => {
+          return CryptoJS.MD5(CryptoJS.enc.Latin1.parse(image)).toString();
+        },
+      });
+
+      appendLog("Resetting device...");
+      await espLoader.after();
+      appendLog("Flash complete!");
+      setFlashState("done");
+    } catch (err) {
+      appendLog(`Flash failed: ${err instanceof Error ? err.message : err}`);
+      setFlashState("error");
+    }
+  }, [boards, selectedBoard, appendLog]);
+
+  // Auto-select the first release when loaded
+  if (releases.length > 0 && !selectedRelease) {
+    setSelectedRelease(releases[0].tag_name);
+  }
+
+  // Auto-select first board when boards change (release changed or loaded)
+  if (boards.length > 0 && !boards.some((b) => b.value === selectedBoard)) {
+    setSelectedBoard(boards[0].value);
+  }
+
+  const isConnected =
+    flashState === "connected" ||
+    flashState === "flashing" ||
+    flashState === "done";
+  const isFlashing = flashState === "flashing";
+
+  return (
+    <Flex
+      direction="column"
+      align="center"
+      style={{ flex: 1, overflow: "auto" }}
+      p="4"
+      gap="4"
+    >
+      <Box style={{ width: "100%", maxWidth: 600 }}>
+        <Heading size="5" mb="4">
+          Firmware Flasher
+        </Heading>
+
+        {!webSerialSupported && (
+          <Callout.Root color="red" mb="4">
+            <Callout.Icon>
+              <ExclamationTriangleIcon />
+            </Callout.Icon>
+            <Callout.Text>
+              Web Serial is not supported in this browser. Please use Chrome or
+              Edge.
+            </Callout.Text>
+          </Callout.Root>
+        )}
+
+        <Card size="2">
+          <Flex direction="column" gap="4">
+            <Flex direction="column" gap="2">
+              <Text size="2" weight="medium" as="label">
+                Release
+              </Text>
+              {releasesLoading ? (
+                <Text size="2" color="gray">
+                  Loading releases...
+                </Text>
+              ) : releasesError ? (
+                <Callout.Root color="red" size="1">
+                  <Callout.Icon>
+                    <ExclamationTriangleIcon />
+                  </Callout.Icon>
+                  <Callout.Text>{releasesError}</Callout.Text>
+                </Callout.Root>
+              ) : (
+                <Select.Root
+                  value={selectedRelease}
+                  onValueChange={setSelectedRelease}
+                  disabled={isConnected}
+                >
+                  <Select.Trigger style={{ width: "100%" }} />
+                  <Select.Content>
+                    {releases.map((r) => (
+                      <Select.Item key={r.tag_name} value={r.tag_name}>
+                        {r.tag_name}
+                        {r.name && r.name !== r.tag_name ? ` — ${r.name}` : ""}
+                      </Select.Item>
+                    ))}
+                  </Select.Content>
+                </Select.Root>
+              )}
+            </Flex>
+
+            <Flex direction="column" gap="2">
+              <Text size="2" weight="medium" as="label">
+                Board
+              </Text>
+              <Select.Root
+                value={selectedBoard}
+                onValueChange={setSelectedBoard}
+                disabled={isConnected || boards.length === 0}
+              >
+                <Select.Trigger style={{ width: "100%" }} />
+                <Select.Content>
+                  {boards.map((b) => (
+                    <Select.Item key={b.value} value={b.value}>
+                      {b.label}
+                    </Select.Item>
+                  ))}
+                </Select.Content>
+              </Select.Root>
+            </Flex>
+
+            <Separator size="4" />
+
+            <Flex gap="2">
+              <Button
+                onClick={handleConnect}
+                disabled={!webSerialSupported || isFlashing}
+                variant={isConnected ? "outline" : "solid"}
+                style={{ flex: 1 }}
+              >
+                {flashState === "connecting"
+                  ? "Connecting..."
+                  : isConnected
+                    ? "Disconnect"
+                    : "Connect"}
+              </Button>
+              <Button
+                onClick={handleFlash}
+                disabled={!isConnected || isFlashing || !selectedRelease}
+                variant="solid"
+                color="green"
+                style={{ flex: 1 }}
+              >
+                {isFlashing ? "Flashing..." : "Flash"}
+              </Button>
+            </Flex>
+
+            {isFlashing && (
+              <Flex direction="column" gap="2">
+                <Flex justify="between">
+                  <Text size="2" weight="medium">
+                    Progress
+                  </Text>
+                  <Text size="2" color="gray">
+                    {progress}%
+                  </Text>
+                </Flex>
+                <Progress value={progress} />
+              </Flex>
+            )}
+
+            {flashState === "done" && (
+              <Callout.Root color="green" size="1">
+                <Callout.Icon>
+                  <InfoCircledIcon />
+                </Callout.Icon>
+                <Callout.Text>
+                  Flash complete! Your device has been updated.
+                </Callout.Text>
+              </Callout.Root>
+            )}
+          </Flex>
+        </Card>
+
+        {logs.length > 0 && (
+          <Card size="2" mt="4">
+            <Text size="2" weight="medium" mb="2" as="p">
+              Log
+            </Text>
+            <ScrollArea
+              style={{
+                height: 200,
+                background: "var(--gray-2)",
+                borderRadius: "var(--radius-2)",
+              }}
+              scrollbars="vertical"
+            >
+              <Code
+                size="1"
+                style={{ whiteSpace: "pre-wrap", display: "block" }}
+              >
+                <Box p="2">{logs.join("\n")}</Box>
+              </Code>
+              <div ref={logEndRef} />
+            </ScrollArea>
+          </Card>
+        )}
+      </Box>
+    </Flex>
+  );
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}

--- a/apps/web-tools/src/pages/SimulatorPage.tsx
+++ b/apps/web-tools/src/pages/SimulatorPage.tsx
@@ -1,0 +1,332 @@
+import { Suspense, useRef, useCallback, useEffect, useMemo } from "react";
+import { useSimulator } from "../hooks/useSimulator";
+import { useEngineState } from "../hooks/useEngineState";
+import { useIsMobile } from "../hooks/useIsMobile";
+import { usePersistedState } from "../hooks/usePersistedState";
+import {
+  Box,
+  Card,
+  Flex,
+  Heading,
+  Text,
+  Slider,
+  Spinner,
+  Select,
+  Button,
+  IconButton,
+  ScrollArea,
+  Separator,
+} from "@radix-ui/themes";
+import {
+  ResetIcon,
+  PlayIcon,
+  PauseIcon,
+  StopIcon,
+} from "@radix-ui/react-icons";
+import Scene from "../Scene";
+import type { SceneHandle } from "../Scene";
+
+export default function SimulatorPage() {
+  const simulator = useSimulator();
+  const sceneRef = useRef<SceneHandle>(null);
+  const [depth, setDepth] = usePersistedState("ossm:depth", 0.5);
+  const [stroke, setStroke] = usePersistedState("ossm:stroke", 0.4);
+  const [velocity, setVelocity] = usePersistedState("ossm:velocity", 0.5);
+  const [sensation, setSensation] = usePersistedState("ossm:sensation", 0.0);
+  const [selectedPattern, setSelectedPattern] = usePersistedState(
+    "ossm:pattern",
+    0,
+  );
+  const playbackState = useEngineState(simulator);
+  const isMobile = useIsMobile();
+
+  useEffect(() => {
+    simulator.set_depth(depth);
+    simulator.set_stroke(stroke);
+    simulator.set_velocity(velocity);
+    simulator.set_sensation(sensation);
+    if (selectedPattern > 0) {
+      simulator.play(selectedPattern);
+    }
+    // Only sync on mount, not on every state change
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [simulator]);
+
+  const patterns = useMemo<
+    { index: number; name: string; description: string }[]
+  >(() => {
+    const count = simulator.pattern_count();
+    return Array.from({ length: count }, (_, i) => ({
+      index: i,
+      name: simulator.pattern_name(i),
+      description: simulator.pattern_description(i),
+    }));
+  }, [simulator]);
+
+  const updateDepth = useCallback(
+    (v: number) => {
+      setDepth(v);
+      simulator.set_depth(v);
+    },
+    [simulator, setDepth],
+  );
+
+  const updateStroke = useCallback(
+    (v: number) => {
+      setStroke(v);
+      simulator.set_stroke(v);
+    },
+    [simulator, setStroke],
+  );
+
+  const updateVelocity = useCallback(
+    (v: number) => {
+      setVelocity(v);
+      simulator.set_velocity(v);
+    },
+    [simulator, setVelocity],
+  );
+
+  const updateSensation = useCallback(
+    (v: number) => {
+      setSensation(v);
+      simulator.set_sensation(v);
+    },
+    [simulator, setSensation],
+  );
+
+  const handlePlay = useCallback(() => {
+    simulator.play(selectedPattern);
+  }, [simulator, selectedPattern]);
+
+  const handlePause = useCallback(() => {
+    simulator.pause();
+  }, [simulator]);
+
+  const handleResume = useCallback(() => {
+    simulator.resume();
+  }, [simulator]);
+
+  const handleStop = useCallback(() => {
+    simulator.stop();
+  }, [simulator]);
+
+  const handlePatternChange = useCallback(
+    (value: string) => {
+      const index = Number(value);
+      setSelectedPattern(index);
+      simulator.play(index);
+    },
+    [simulator, setSelectedPattern],
+  );
+
+  return (
+    <Flex direction={isMobile ? "column" : "row"} gap="3" p="3" style={{ flex: 1 }}>
+      <Box
+        style={{
+          flex: isMobile ? undefined : 1,
+          height: isMobile ? "30vh" : undefined,
+          minHeight: 0,
+          position: "relative",
+        }}
+      >
+        <Box
+          style={{
+            width: "100%",
+            height: "100%",
+            borderRadius: "var(--radius-4)",
+            overflow: "hidden",
+          }}
+        >
+          <Suspense
+            fallback={
+              <Flex align="center" justify="center" height="100%" gap="3">
+                <Spinner size="3" />
+                <Text size="2">Loading model…</Text>
+              </Flex>
+            }
+          >
+            <Scene
+              ref={sceneRef}
+              simulator={simulator}
+              zoom={isMobile ? 900 : 1500}
+            />
+          </Suspense>
+        </Box>
+      </Box>
+
+      <Box
+        style={{
+          width: isMobile ? undefined : "360px",
+          height: isMobile ? "70vh" : undefined,
+          flexShrink: 0,
+        }}
+      >
+        <Card
+          size="2"
+          style={{
+            height: "100%",
+            display: "flex",
+            flexDirection: "column",
+          }}
+        >
+          <Heading size="5" mb="3">
+            Simulator
+          </Heading>
+
+          <Separator size="4" mb="3" />
+
+          <ScrollArea style={{ flex: 1 }} scrollbars="vertical">
+            <Flex direction="column" gap="4" pr="1">
+              <Box>
+                <Text size="2" weight="medium" mb="1" as="label">
+                  Pattern
+                </Text>
+                <Select.Root
+                  value={String(selectedPattern)}
+                  onValueChange={handlePatternChange}
+                >
+                  <Select.Trigger style={{ width: "100%" }} />
+                  <Select.Content>
+                    {patterns.map((p) => (
+                      <Select.Item key={p.index} value={String(p.index)}>
+                        {p.name}
+                      </Select.Item>
+                    ))}
+                  </Select.Content>
+                </Select.Root>
+                {patterns[selectedPattern] && (
+                  <Text size="1" color="gray" mt="1">
+                    {patterns[selectedPattern].description}
+                  </Text>
+                )}
+              </Box>
+
+              <Flex gap="2" align="center">
+                <IconButton
+                  onClick={
+                    playbackState === "playing" || playbackState === "homing"
+                      ? handlePause
+                      : playbackState === "paused"
+                        ? handleResume
+                        : handlePlay
+                  }
+                  variant="solid"
+                  size="3"
+                  aria-label={
+                    playbackState === "playing" || playbackState === "homing"
+                      ? "Pause"
+                      : playbackState === "paused"
+                        ? "Resume"
+                        : "Play"
+                  }
+                >
+                  {playbackState === "playing" ||
+                  playbackState === "homing" ? (
+                    <PauseIcon />
+                  ) : (
+                    <PlayIcon />
+                  )}
+                </IconButton>
+                <IconButton
+                  onClick={handleStop}
+                  variant="outline"
+                  size="3"
+                  disabled={playbackState === "stopped"}
+                  aria-label="Stop"
+                >
+                  <StopIcon />
+                </IconButton>
+                <Text size="2" color="gray" ml="1">
+                  {playbackState.charAt(0).toUpperCase() +
+                    playbackState.slice(1)}
+                </Text>
+              </Flex>
+
+              <Separator size="4" />
+
+              <LabeledSlider
+                label="Depth"
+                value={depth}
+                min={0}
+                max={1}
+                step={0.01}
+                onChange={updateDepth}
+              />
+              <LabeledSlider
+                label="Stroke"
+                value={stroke}
+                min={0}
+                max={1}
+                step={0.01}
+                onChange={updateStroke}
+              />
+              <LabeledSlider
+                label="Velocity"
+                value={velocity}
+                min={0}
+                max={1}
+                step={0.01}
+                onChange={updateVelocity}
+              />
+              <LabeledSlider
+                label="Sensation"
+                value={sensation}
+                min={-1}
+                max={1}
+                step={0.01}
+                onChange={updateSensation}
+              />
+
+              <Separator size="4" />
+
+              <Button
+                variant="outline"
+                onClick={() => sceneRef.current?.resetView()}
+                style={{ width: "100%" }}
+              >
+                <ResetIcon /> Reset View
+              </Button>
+            </Flex>
+          </ScrollArea>
+        </Card>
+      </Box>
+    </Flex>
+  );
+}
+
+function LabeledSlider({
+  label,
+  value,
+  min,
+  max,
+  step,
+  onChange,
+}: {
+  label: string;
+  value: number;
+  min: number;
+  max: number;
+  step: number;
+  onChange: (v: number) => void;
+}) {
+  return (
+    <Box>
+      <Flex justify="between" mb="1">
+        <Text size="2" weight="medium">
+          {label}
+        </Text>
+        <Text size="2" color="gray">
+          {value}
+        </Text>
+      </Flex>
+      <Slider
+        min={min}
+        max={max}
+        step={step}
+        value={[value]}
+        onValueChange={(values) => onChange(values[0])}
+      />
+    </Box>
+  );
+}

--- a/apps/web-tools/tsconfig.app.json
+++ b/apps/web-tools/tsconfig.app.json
@@ -3,6 +3,7 @@
     "target": "ES2020",
     "useDefineForClassFields": true,
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "types": ["w3c-web-serial"],
     "module": "ESNext",
     "skipLibCheck": true,
     "moduleResolution": "bundler",
@@ -17,5 +18,6 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/api"]
 }

--- a/apps/web-tools/tsconfig.node.json
+++ b/apps/web-tools/tsconfig.node.json
@@ -6,6 +6,7 @@
     "allowImportingTsExtensions": true,
     "noEmit": true,
     "strict": true,
+    "skipLibCheck": true,
     "types": ["node"]
   },
   "include": ["vite.config.ts"]

--- a/apps/web-tools/vite.config.ts
+++ b/apps/web-tools/vite.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig, type Plugin } from "vite";
+import { cloudflare } from "@cloudflare/vite-plugin";
 import react from "@vitejs/plugin-react";
 import wasm from "vite-plugin-wasm";
 import topLevelAwait from "vite-plugin-top-level-await";
@@ -80,5 +81,5 @@ export default defineConfig({
       ignored: ["**/firmware/sim-wasm/pkg/**"],
     },
   },
-  plugins: [react(), wasm(), topLevelAwait(), wasmHotReload()],
+  plugins: [react(), wasm(), topLevelAwait(), wasmHotReload(), cloudflare()],
 });

--- a/apps/web-tools/wrangler.toml
+++ b/apps/web-tools/wrangler.toml
@@ -1,12 +1,13 @@
 name = "web-tools"
-compatibility_date = "2026-03-25"
+main = "src/api/index.ts"
+compatibility_date = "2026-03-17"
 
-routes = [
-  { pattern = "web-tools.ossm.rs", custom_domain = true },
-]
+routes = [{ pattern = "web-tools.ossm.rs", custom_domain = true }]
 
 [assets]
 directory = "dist"
+binding = "ASSETS"
+not_found_handling = "single-page-application"
 
 [observability]
 enabled = false

--- a/docs/so-you-want-to-add-a-pattern.md
+++ b/docs/so-you-want-to-add-a-pattern.md
@@ -36,7 +36,7 @@ Then add the WASM target and install simulator dependencies:
 
 ```sh
 rustup target add wasm32-unknown-unknown
-pnpm install --dir apps/simulator
+pnpm install --dir apps/web-tools
 ```
 
 ## Running the Simulator
@@ -48,9 +48,15 @@ just dev-patterns
 This does two things in sequence:
 
 1. **`build-wasm`** - runs `wasm-pack build firmware/sim-wasm --target web`, which compiles the pattern engine (and its WASM firmware wrapper) into a WebAssembly module.
-2. **`dev`** - starts the Vite dev server in `apps/simulator/` with `--host` so you can access it from other devices on your network.
+2. **`dev`** - starts the Vite dev server in `apps/web-tools/` with `--host` so you can access it from other devices on your network.
 
 The simulator renders a 3D model of the OSSM and runs your patterns in the browser. Change a pattern and the wasm will recompile and the browser will reload.
+
+### Cloudflare Worker Functions
+
+The web tools app includes Cloudflare Worker functions (e.g. the GitHub asset proxy used by the flasher) in `src/api/`. The Cloudflare Vite plugin runs these in the local `workerd` runtime during `pnpm dev`, so both the SPA and `/api/*` routes work with HMR out of the box.
+
+Cloudflare Worker functions should be used sparingly and only when entirely necessary (e.g. proxying requests to avoid CORS issues). Prefer doing work client-side wherever possible.
 
 ## Adding a New Pattern
 

--- a/justfile
+++ b/justfile
@@ -37,7 +37,7 @@ build-wasm:
     wasm-pack build firmware/sim-wasm --target web
 
 # Dev server (watches Rust sources and hot-reloads WASM)
-[working-directory: 'apps/simulator']
+[working-directory: 'apps/web-tools']
 dev-patterns: build-wasm
     pnpm dev --host
 


### PR DESCRIPTION
## Problem

At present you must flash your ossm by downloading or building your own firmware via espflash. This is a barrier to entry most will not hurdle, so we need something simpler.

## Solution

Inspired by @orange-gem's web flasher, I've built this one, reworked the simulator to 'web-tools' and included two different pages. The builds are pulled from the releases of the public repo to keep it all up to date nicely.

## Testing

Visit the site an flash your board :smile:

Closes #40