### PR TITLE
feat: Add build info to all builds, log on power on

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,10 @@ on:
         description: Upload firmware binaries as artifacts
         type: boolean
         default: false
+      release-id:
+        description: Release identifier baked into the firmware image (e.g. tag or PR number)
+        type: string
+        default: dev
 
 env:
   CARGO_TERM_COLOR: always
@@ -36,6 +40,8 @@ jobs:
 
       - name: Build ${{ matrix.firmware }}
         run: just build-${{ matrix.firmware }}
+        env:
+          OSSM_RELEASE_ID: ${{ inputs.release-id }}
 
       - name: Install espflash
         run: |
@@ -70,3 +76,5 @@ jobs:
 
       - name: Build WASM
         run: wasm-pack build firmware/sim-wasm --target web
+        env:
+          OSSM_RELEASE_ID: ${{ inputs.release-id }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
     uses: ./.github/workflows/build.yml
     with:
       upload-artifacts: ${{ github.event_name == 'pull_request' || github.ref == 'refs/heads/main' }}
+      release-id: ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || 'main' }}
 
   build-windows:
     uses: ./.github/workflows/build-windows.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ jobs:
     uses: ./.github/workflows/build.yml
     with:
       upload-artifacts: true
+      release-id: ${{ needs.tag.outputs.new_tag }}
 
   release:
     name: Create release

--- a/firmware/ossm-alt/build.rs
+++ b/firmware/ossm-alt/build.rs
@@ -1,7 +1,33 @@
 fn main() {
+    emit_build_info();
     linker_be_nice();
     // make sure linkall.x is the last linker script (otherwise might cause problems with flip-link)
     println!("cargo:rustc-link-arg=-Tlinkall.x");
+}
+
+fn emit_build_info() {
+    println!("cargo:rustc-env=OSSM_DEVICE={}", std::env::var("CARGO_PKG_NAME").unwrap());
+
+    let commit = std::process::Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .unwrap_or_else(|| "unknown".into());
+    println!("cargo:rustc-env=OSSM_COMMIT_HASH={commit}");
+
+    let release_id = std::env::var("OSSM_RELEASE_ID").unwrap_or_else(|_| "dev".into());
+    println!("cargo:rustc-env=OSSM_RELEASE_ID={release_id}");
+
+    let build_time = std::process::Command::new("date")
+        .args(["-u", "+%Y-%m-%dT%H:%M:%SZ"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .unwrap_or_else(|| "unknown".into());
+    println!("cargo:rustc-env=OSSM_BUILD_TIME={build_time}");
 }
 
 fn linker_be_nice() {

--- a/firmware/ossm-alt/src/main.rs
+++ b/firmware/ossm-alt/src/main.rs
@@ -82,6 +82,8 @@ async fn main(spawner: Spawner) {
         esp_println::println!("{}", line);
     });
 
+    ossm::build_info!();
+
     let p = esp_hal::init(esp_hal::Config::default());
 
     esp_alloc::heap_allocator!(size: 128 * 1024);

--- a/firmware/sim-wasm/build.rs
+++ b/firmware/sim-wasm/build.rs
@@ -1,0 +1,24 @@
+fn main() {
+    println!("cargo:rustc-env=OSSM_DEVICE={}", std::env::var("CARGO_PKG_NAME").unwrap());
+
+    let commit = std::process::Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .unwrap_or_else(|| "unknown".into());
+    println!("cargo:rustc-env=OSSM_COMMIT_HASH={commit}");
+
+    let release_id = std::env::var("OSSM_RELEASE_ID").unwrap_or_else(|_| "dev".into());
+    println!("cargo:rustc-env=OSSM_RELEASE_ID={release_id}");
+
+    let build_time = std::process::Command::new("date")
+        .args(["-u", "+%Y-%m-%dT%H:%M:%SZ"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .unwrap_or_else(|| "unknown".into());
+    println!("cargo:rustc-env=OSSM_BUILD_TIME={build_time}");
+}

--- a/firmware/sim-wasm/src/lib.rs
+++ b/firmware/sim-wasm/src/lib.rs
@@ -37,6 +37,8 @@ impl Simulator {
             web_sys::console::log_1(&wasm_bindgen::JsValue::from_str(line));
         });
 
+        ossm::build_info!();
+
         let update_interval_secs = update_interval_ms / 1000.0;
         let motor = SimMotor::new(&MOTOR_POSITION);
         let board = SimBoard::new(motor, &MECHANICAL);

--- a/firmware/waveshare/build.rs
+++ b/firmware/waveshare/build.rs
@@ -1,7 +1,33 @@
 fn main() {
+    emit_build_info();
     linker_be_nice();
     // make sure linkall.x is the last linker script (otherwise might cause problems with flip-link)
     println!("cargo:rustc-link-arg=-Tlinkall.x");
+}
+
+fn emit_build_info() {
+    println!("cargo:rustc-env=OSSM_DEVICE={}", std::env::var("CARGO_PKG_NAME").unwrap());
+
+    let commit = std::process::Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .unwrap_or_else(|| "unknown".into());
+    println!("cargo:rustc-env=OSSM_COMMIT_HASH={commit}");
+
+    let release_id = std::env::var("OSSM_RELEASE_ID").unwrap_or_else(|_| "dev".into());
+    println!("cargo:rustc-env=OSSM_RELEASE_ID={release_id}");
+
+    let build_time = std::process::Command::new("date")
+        .args(["-u", "+%Y-%m-%dT%H:%M:%SZ"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .unwrap_or_else(|| "unknown".into());
+    println!("cargo:rustc-env=OSSM_BUILD_TIME={build_time}");
 }
 
 fn linker_be_nice() {

--- a/firmware/waveshare/src/main.rs
+++ b/firmware/waveshare/src/main.rs
@@ -78,6 +78,8 @@ async fn motion_task(mut controller: MotionController<'static, ConcreteBoard>) {
 async fn main(spawner: Spawner) {
     esp_println::logger::init_logger_from_env();
 
+    ossm::build_info!();
+
     let p = esp_hal::init(esp_hal::Config::default());
 
     esp_alloc::heap_allocator!(size: 128 * 1024);

--- a/ossm/src/build_info.rs
+++ b/ossm/src/build_info.rs
@@ -1,0 +1,16 @@
+/// Logs build metadata baked in by the firmware's `build.rs`.
+///
+/// Must be invoked from a firmware crate whose `build.rs` emits
+/// `OSSM_DEVICE`, `OSSM_COMMIT_HASH`, `OSSM_RELEASE_ID`, and `OSSM_BUILD_TIME`.
+#[macro_export]
+macro_rules! build_info {
+    () => {
+        log::info!(
+            "{} {} (release: {}, built: {})",
+            env!("OSSM_DEVICE"),
+            env!("OSSM_COMMIT_HASH"),
+            env!("OSSM_RELEASE_ID"),
+            env!("OSSM_BUILD_TIME"),
+        )
+    };
+}

--- a/ossm/src/lib.rs
+++ b/ossm/src/lib.rs
@@ -2,6 +2,7 @@
 extern crate alloc;
 
 mod board;
+mod build_info;
 mod command;
 mod limits;
 pub mod logging;


### PR DESCRIPTION
## Problem

It's not obvious which firmware users are running

## Solution

Bake the firmware name, commit hash, release and build time into the firmware and emit them on initial run.

## Testing

Tested on ossm-alt