### PR TITLE
fix: Prevent phantom M5 remote connection on startup

### DIFF
--- a/features/ossm-m5-remote/src/lib.rs
+++ b/features/ossm-m5-remote/src/lib.rs
@@ -369,11 +369,12 @@ async fn heartbeat_check_task(engine: &'static PatternEngine) {
     loop {
         ticker.next().await;
 
-        let last_heartbeat = Instant::from_millis(LAST_HEARTBEAT.load(Ordering::Acquire));
-        let elapsed = last_heartbeat.elapsed().as_millis();
-
+        let last_heartbeat_ms = LAST_HEARTBEAT.load(Ordering::Acquire);
         let was_connected = CONNECTED.load(Ordering::Acquire);
-        let is_connected = elapsed <= MAX_NO_REMOTE_HEARTBEAT_MS;
+        let is_connected = last_heartbeat_ms > 0 && {
+            let elapsed = Instant::from_millis(last_heartbeat_ms).elapsed().as_millis();
+            elapsed <= MAX_NO_REMOTE_HEARTBEAT_MS
+        };
 
         CONNECTED.store(is_connected, Ordering::Release);
 


### PR DESCRIPTION
## Problem

On startup, the ESP-NOW heartbeat check task falsely detects a remote connection

## Solution

Require is_connected to have at least a single heartbeat before assuming a device has connected.

## Testing

1. Flash to ossm-alt or waveshare
2. Check logs to make sure the M5 remote hasn't connected the disconnects 10 seconds later.

## Notes

It is what causes multiple homing flows in short succession.