### PR TITLE
refactor(m57aim): Moves baud rate and device addr to motor

### DIFF
--- a/drivers/m57aim/src/lib.rs
+++ b/drivers/m57aim/src/lib.rs
@@ -55,6 +55,10 @@ impl Default for Motor57AIMConfig {
     }
 }
 
+pub const DEFAULT_DEVICE_ADDR: u8 = 0x01;
+pub const STOCK_BAUD_RATE: u32 = 19_200;
+pub const TARGET_BAUD_RATE: u32 = 115_200;
+
 /// 57AIM BLDC servo motor, generic over communication interface and delay.
 pub struct Motor57AIM<I, D> {
     pub(crate) interface: I,

--- a/firmware/ossm-alt/src/main.rs
+++ b/firmware/ossm-alt/src/main.rs
@@ -25,7 +25,7 @@ use esp_radio::ble::controller::BleConnector;
 use esp_radio::esp_now::{EspNowManager, EspNowSender};
 use esp_rtos::embassy::InterruptExecutor;
 use log::info;
-use m57aim_motor::{Modbus, Motor57AIM, Motor57AIMConfig};
+use m57aim_motor::{DEFAULT_DEVICE_ADDR, Modbus, Motor57AIM, Motor57AIMConfig, TARGET_BAUD_RATE};
 use ossm::{MechanicalConfig, MotionController, MotionLimits, Ossm};
 
 use ossm_m5_remote::RemoteConfig;
@@ -41,8 +41,6 @@ extern crate alloc;
 esp_bootloader_esp_idf::esp_app_desc!();
 
 const UPDATE_INTERVAL_SECS: f64 = 0.01;
-const MOTOR_BAUD_RATE: u32 = 115_200;
-const DEVICE_ADDR: u8 = 0x01;
 
 macro_rules! mk_static {
     ($t:ty, $val:expr) => {{
@@ -91,7 +89,7 @@ async fn main(spawner: Spawner) {
     let timg0 = TimerGroup::new(p.TIMG0);
     esp_rtos::start(timg0.timer0);
 
-    let uart_config = Config::default().with_baudrate(MOTOR_BAUD_RATE);
+    let uart_config = Config::default().with_baudrate(TARGET_BAUD_RATE);
     let uart = Uart::new(p.UART1, uart_config)
         .expect("Failed to initialize UART")
         .with_tx(p.GPIO10)
@@ -104,7 +102,7 @@ async fn main(spawner: Spawner) {
 
     let transport = Rs485ModbusTransport::new(rs485, Delay);
     let motor = Motor57AIM::new(
-        Modbus::new(transport, DEVICE_ADDR),
+        Modbus::new(transport, DEFAULT_DEVICE_ADDR),
         Motor57AIMConfig::default(),
         Delay,
     );

--- a/firmware/seeed-xiao/src/main.rs
+++ b/firmware/seeed-xiao/src/main.rs
@@ -25,7 +25,7 @@ use esp_radio::ble::controller::BleConnector;
 use esp_radio::esp_now::{EspNowManager, EspNowSender};
 use esp_rtos::embassy::InterruptExecutor;
 use log::info;
-use m57aim_motor::{Modbus, Motor57AIM, Motor57AIMConfig};
+use m57aim_motor::{DEFAULT_DEVICE_ADDR, Modbus, Motor57AIM, Motor57AIMConfig, TARGET_BAUD_RATE};
 use ossm::{MechanicalConfig, MotionController, MotionLimits, Ossm};
 
 use rs485_board::{Rs485Board, Rs485, Rs485ModbusTransport};
@@ -41,8 +41,6 @@ extern crate alloc;
 esp_bootloader_esp_idf::esp_app_desc!();
 
 const UPDATE_INTERVAL_SECS: f64 = 0.01;
-const MOTOR_BAUD_RATE: u32 = 115_200;
-const DEVICE_ADDR: u8 = 0x01;
 
 macro_rules! mk_static {
     ($t:ty, $val:expr) => {{
@@ -89,7 +87,7 @@ async fn main(spawner: Spawner) {
     let timg0 = TimerGroup::new(p.TIMG0);
     esp_rtos::start(timg0.timer0);
 
-    let uart_config = Config::default().with_baudrate(MOTOR_BAUD_RATE);
+    let uart_config = Config::default().with_baudrate(TARGET_BAUD_RATE);
     let uart = Uart::new(p.UART1, uart_config)
         .expect("Failed to initialize UART")
         .with_tx(p.GPIO5)
@@ -100,7 +98,7 @@ async fn main(spawner: Spawner) {
 
     let transport = Rs485ModbusTransport::new(rs485, Delay);
     let motor = Motor57AIM::new(
-        Modbus::new(transport, DEVICE_ADDR),
+        Modbus::new(transport, DEFAULT_DEVICE_ADDR),
         Motor57AIMConfig::default(),
         Delay,
     );

--- a/firmware/waveshare/src/main.rs
+++ b/firmware/waveshare/src/main.rs
@@ -25,7 +25,7 @@ use esp_radio::ble::controller::BleConnector;
 use esp_radio::esp_now::{EspNowManager, EspNowSender};
 use esp_rtos::embassy::InterruptExecutor;
 use log::info;
-use m57aim_motor::{Modbus, Motor57AIM, Motor57AIMConfig};
+use m57aim_motor::{DEFAULT_DEVICE_ADDR, Modbus, Motor57AIM, Motor57AIMConfig, TARGET_BAUD_RATE};
 use ossm::{MechanicalConfig, MotionController, MotionLimits, Ossm};
 
 use ossm_m5_remote::RemoteConfig;
@@ -41,8 +41,6 @@ extern crate alloc;
 esp_bootloader_esp_idf::esp_app_desc!();
 
 const UPDATE_INTERVAL_SECS: f64 = 0.01;
-const MOTOR_BAUD_RATE: u32 = 115_200;
-const DEVICE_ADDR: u8 = 0x01;
 
 macro_rules! mk_static {
     ($t:ty, $val:expr) => {{
@@ -91,7 +89,7 @@ async fn main(spawner: Spawner) {
     let timg0 = TimerGroup::new(p.TIMG0);
     esp_rtos::start(timg0.timer0);
 
-    let uart_config = Config::default().with_baudrate(MOTOR_BAUD_RATE);
+    let uart_config = Config::default().with_baudrate(TARGET_BAUD_RATE);
     let uart = Uart::new(p.UART1, uart_config)
         .expect("Failed to initialize UART")
         .with_tx(p.GPIO17)
@@ -102,7 +100,7 @@ async fn main(spawner: Spawner) {
 
     let transport = Rs485ModbusTransport::new(rs485, Delay);
     let motor = Motor57AIM::new(
-        Modbus::new(transport, DEVICE_ADDR),
+        Modbus::new(transport, DEFAULT_DEVICE_ADDR),
         Motor57AIMConfig::default(),
         Delay,
     );


### PR DESCRIPTION
## Problem

There is unneeded duplication of the baudrate and address of the motor in the firmware

## Solution

Move both of these to the motor

## Testing

1. Flash to any supported board /w motor
2. Observe no change