### PR TITLE
fix: BLE remote to match reference and saftey changes in pattern engine

### DIFF
--- a/features/ble-remote/src/lib.rs
+++ b/features/ble-remote/src/lib.rs
@@ -140,7 +140,7 @@ pub async fn ble_events_task(
     .unwrap();
 
     loop {
-        match advertise("OSSM", &mut peripheral).await {
+        match advertise("OSSM-rs", &mut peripheral).await {
             Ok(connection) => {
                 CONNECTED.store(true, Ordering::Release);
                 info!("BLE Connected");
@@ -197,8 +197,8 @@ pub async fn ble_events_task(
                     },
                 }
 
-                let state = engine.state();
-                info!("BLE session ended, engine state: {:?}", state);
+                engine.stop();
+                info!("BLE session ended, stopping engine");
             }
             Err(err) => {
                 error!("[adv] error: {:?}", err);
@@ -247,7 +247,7 @@ async fn gatt_events_task<P: PacketPool>(
                         write = true;
                         event_handle = event.handle();
                     }
-                    _ => {}
+                    GattEvent::Other(_) => {}
                 };
                 // This step is also performed at drop(), but writing it explicitly is necessary
                 // in order to ensure reply is sent.
@@ -284,7 +284,10 @@ async fn gatt_events_task<P: PacketPool>(
                     }
                 }
             }
-            _ => {} // ignore other Gatt Connection Events
+            GattConnectionEvent::PhyUpdated { .. }
+            | GattConnectionEvent::ConnectionParamsUpdated { .. }
+            | GattConnectionEvent::RequestConnectionParams { .. }
+            | GattConnectionEvent::DataLengthUpdated { .. } => {}
         }
     };
     CONNECTED.store(false, Ordering::Release);
@@ -458,7 +461,7 @@ fn process_command(
                 }
                 "go" => match action {
                     "simplePenetration" => engine.play(0),
-                    "strokeEngine" => engine.home(),
+                    "strokeEngine" => engine.play(0),
                     "menu" => engine.stop(),
                     _ => {
                         error!("Unknown go action: {}", action);

--- a/features/pattern-engine/src/engine.rs
+++ b/features/pattern-engine/src/engine.rs
@@ -180,6 +180,7 @@ impl PatternEngine {
 
     pub fn stop(&self) {
         let _ = self.channels.commands.try_send(EngineCommand::Stop);
+        self.input.sender().send(PatternInput::DEFAULT);
     }
 
     pub fn home(&self) {
@@ -248,23 +249,37 @@ impl<const N: usize> PatternEngineRunner<N> {
                         continue;
                     }
 
-                    let result =
-                        select::select(ossm.home(), self.engine.channels.commands.receive()).await;
+                    let home_fut = ossm.home();
+                    let mut home_fut = core::pin::pin!(home_fut);
 
-                    match result {
-                        Either::First(resp) => {
-                            if resp != StateResponse::Completed {
-                                log::error!("Home failed, returning to idle");
+                    loop {
+                        let result = select::select(
+                            home_fut.as_mut(),
+                            self.engine.channels.commands.receive(),
+                        )
+                        .await;
+
+                        match result {
+                            Either::First(resp) => {
+                                if resp != StateResponse::Completed {
+                                    log::error!("Home failed, returning to idle");
+                                    self.set_state(RunnerState::Idle);
+                                } else {
+                                    match maybe_idx {
+                                        Some(idx) => self.set_state(RunnerState::Playing(idx)),
+                                        None => self.set_state(RunnerState::Ready),
+                                    }
+                                }
+                                break;
+                            }
+                            Either::Second(EngineCommand::Stop) => {
+                                if ossm.disable().await == StateResponse::Fault {
+                                    log::error!("Board fault during disable");
+                                }
                                 self.set_state(RunnerState::Idle);
-                                continue;
+                                break;
                             }
-                            match maybe_idx {
-                                Some(idx) => self.set_state(RunnerState::Playing(idx)),
-                                None => self.set_state(RunnerState::Ready),
-                            }
-                        }
-                        Either::Second(cmd) => {
-                            self.handle_command(cmd).await;
+                            Either::Second(_) => {}
                         }
                     }
                 }
@@ -367,11 +382,13 @@ impl<const N: usize> PatternEngineRunner<N> {
         match cmd {
             EngineCommand::Play(idx) => {
                 if idx < N {
-                    let next = match self.state {
-                        RunnerState::Idle => RunnerState::Homing(Some(idx)),
-                        _ => RunnerState::Playing(idx),
+                    match self.state {
+                        RunnerState::Idle => self.set_state(RunnerState::Homing(Some(idx))),
+                        RunnerState::Homing(_) => {
+                            log::warn!("Ignoring Play command while homing");
+                        }
+                        _ => self.set_state(RunnerState::Playing(idx)),
                     };
-                    self.set_state(next);
                 }
             }
             EngineCommand::Stop => {

--- a/features/pattern-engine/src/input.rs
+++ b/features/pattern-engine/src/input.rs
@@ -18,7 +18,7 @@ impl PatternInput {
     pub const DEFAULT: Self = Self {
         depth: 0.5,
         stroke: 0.5,
-        velocity: 0.5,
+        velocity: 0.0,
         sensation: 0.0,
     };
 }


### PR DESCRIPTION
## Problem

There are a number of issues with the BLE remote not acting like ossm reference.

## Solution

Fix the various issues, full explanation added in line by line comments.

## Testing

Flashed to OSSM-alt and thoroughly tested