### PR TITLE
feat(ossm-reference): Adds initial ossm reference firmware

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,20 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        firmware: [ossm-alt, waveshare, seeed-xiao]
+        firmware: [ossm-alt, waveshare, seeed-xiao, ossm-reference]
+        include:
+          - firmware: ossm-alt
+            chip: esp32s3
+            target: xtensa-esp32s3-none-elf
+          - firmware: waveshare
+            chip: esp32s3
+            target: xtensa-esp32s3-none-elf
+          - firmware: seeed-xiao
+            chip: esp32s3
+            target: xtensa-esp32s3-none-elf
+          - firmware: ossm-reference
+            chip: esp32
+            target: xtensa-esp32-none-elf
     steps:
       - uses: actions/checkout@v5
 
@@ -51,7 +64,7 @@ jobs:
           sudo mv espflash /usr/local/bin/
 
       - name: Validate firmware binary
-        run: espflash save-image --merge --chip esp32s3 --partition-table firmware/${{ matrix.firmware }}/partitions.csv target/xtensa-esp32s3-none-elf/release/${{ matrix.firmware }} ${{ matrix.firmware }}.bin
+        run: espflash save-image --merge --chip ${{ matrix.chip }} --partition-table firmware/${{ matrix.firmware }}/partitions.csv target/${{ matrix.target }}/release/${{ matrix.firmware }} ${{ matrix.firmware }}.bin
 
       - name: Upload artifact
         if: inputs.upload-artifacts

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1381,6 +1381,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ossm-reference"
+version = "0.1.0"
+dependencies = [
+ "ble-remote",
+ "critical-section",
+ "embassy-executor",
+ "embassy-futures",
+ "embassy-sync 0.7.2",
+ "embassy-time",
+ "esp-alloc",
+ "esp-backtrace",
+ "esp-bootloader-esp-idf",
+ "esp-hal",
+ "esp-println",
+ "esp-radio",
+ "esp-rtos",
+ "log",
+ "m57aim-motor",
+ "nb 1.1.0",
+ "ossm",
+ "pattern-engine",
+ "portable-atomic",
+ "static_cell",
+ "stepdir-board",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1810,6 +1837,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0530892bb4fa575ee0da4b86f86c667132a94b74bb72160f58ee5a4afec74c23"
 dependencies = [
  "portable-atomic",
+]
+
+[[package]]
+name = "stepdir-board"
+version = "0.1.0"
+dependencies = [
+ "embedded-hal-async",
+ "log",
+ "ossm",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,13 @@ debug-assertions = false
 opt-level = 's'
 overflow-checks = false
 
+[profile.release.package.ossm-reference]
+codegen-units = 1
+debug = 2
+debug-assertions = false
+opt-level = 's'
+overflow-checks = false
+
 
 [profile.release.package.sim-wasm]
 codegen-units = 1

--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ Boards:
 
   A cheap, compact, powerful s3 board with built in 28v USB-PD.
 
+- [OSSM Reference Board](https://github.com/KinkyMakers/OSSM-hardware) (ESP32, step/dir)
+  The original OSSM PCB with step/dir motor control and current-sensing homing.
+
 - [Industrial ESP32-S3-RS485-CAN](https://www.waveshare.com/esp32-s3-rs485-can.htm) by WaveShare
 
 - Seeed Studio's Xiao ESP32-S3
@@ -45,7 +48,7 @@ Boards:
 
 Motors:
 
-- 57AIM series motor
+- 57AIM series motor (RS485/Modbus or step/dir)
 
 ## Installing firmware
 
@@ -76,7 +79,7 @@ While every precaution has been taken to make this software as safe as possible,
 - Trait-based hardware abstraction for motors and boards
 - Optional motor telemetry (position, speed, current, voltage, temperature)
 - Fully async, lock-free architecture built on Embassy channels and signals
-- no_std compatible - runs on bare-metal embedded targets like ESP32-S3
+- no_std compatible - runs on bare-metal embedded targets like ESP32 and ESP32-S3
 
 ## Anatomy
 
@@ -145,7 +148,7 @@ Features are optional higher-level capabilities built on top of the core motion 
    espup install
    ```
 
-   This adds the `xtensa` target and the `+esp` toolchain needed to compile for ESP32-S3.
+   This adds the `xtensa` target and the `+esp` toolchain needed to compile for ESP32 and ESP32-S3.
 
 3. **Install [just](https://github.com/casey/just)** (a command runner used for build recipes):
 
@@ -175,23 +178,26 @@ Features are optional higher-level capabilities built on top of the core motion 
 5. You should now be able to build and flash:
 
    ```sh
-   just build-ossm-alt    # OSSM Alt Edition
-   just build-waveshare   # Waveshare ESP32-S3-RS485-CAN
-   just build-seeed-xiao  # Seeed Studio XIAO ESP32-S3
+   just build-ossm-alt        # OSSM Alt Edition (ESP32-S3, RS485)
+   just build-ossm-reference  # OSSM Reference Board (ESP32, step/dir)
+   just build-waveshare       # Waveshare ESP32-S3-RS485-CAN
+   just build-seeed-xiao      # Seeed Studio XIAO ESP32-S3
 
-   just flash-ossm-alt    # Build + flash OSSM Alt Edition
-   just flash-waveshare   # Build + flash Waveshare
-   just flash-seeed-xiao  # Build + flash Seeed XIAO
+   just flash-ossm-alt        # Build + flash OSSM Alt Edition
+   just flash-ossm-reference  # Build + flash OSSM Reference Board
+   just flash-waveshare       # Build + flash Waveshare
+   just flash-seeed-xiao      # Build + flash Seeed XIAO
    ```
 
 #### Configuring rust-analyzer
 
-This project targets multiple architectures (ESP32, ESP32-S3, WASM), each with its own Rust target triple and cargo features. Since rust-analyzer can only analyze one target at a time, it needs to be told which one to use - otherwise it defaults to your host platform and will report false errors for embedded or WASM code.
+This project targets multiple architectures (ESP32-S3, ESP32, WASM), each with its own Rust target triple and toolchain settings. Since rust-analyzer can only analyze one target at a time, it needs to be told which one to use - otherwise it defaults to your host platform and will report false errors for embedded or WASM code.
 
 The `just focus` command links a firmware's config tomls to the workspace root to configure the correct target and features:
 
 ```sh
 just focus ossm-alt
+just focus ossm-reference
 just focus wasm
 ```
 

--- a/apps/web-tools/src/pages/FlasherPage.tsx
+++ b/apps/web-tools/src/pages/FlasherPage.tsx
@@ -33,6 +33,7 @@ const BAUD = 921600;
 
 const BOARD_LABELS: Record<string, string> = {
   "ossm-alt": "OSSM Alt",
+  "ossm-reference": "OSSM Reference Board",
   waveshare: "Waveshare ESP32-S3-RS485-CAN",
   "seeed-xiao": "Seeed XIAO ESP32S3",
 };

--- a/boards/stepdir/Cargo.toml
+++ b/boards/stepdir/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "stepdir-board"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+ossm = { path = "../../ossm" }
+embedded-hal-async = "1.0"
+log = "0.4"

--- a/boards/stepdir/src/lib.rs
+++ b/boards/stepdir/src/lib.rs
@@ -1,0 +1,190 @@
+#![no_std]
+
+use embedded_hal_async::delay::DelayNs;
+use log::info;
+use ossm::{Board, CurrentSensor, MechanicalConfig, StepDir};
+
+#[derive(Debug)]
+pub enum BoardError<M: core::fmt::Debug, C: core::fmt::Debug> {
+    Motor(M),
+    CurrentSensor(C),
+    HomingTimeout,
+}
+
+#[derive(Debug, Clone, Copy)]
+#[repr(i32)]
+pub enum Direction {
+    Forward = -1,
+    Backward = 1,
+}
+
+pub struct HomingConfig {
+    /// How far the motor crawls per polling iteration during homing (mm).
+    /// Effective crawl speed = crawl_mm_per_poll * 1000 / poll_delay_ms.
+    pub crawl_mm_per_poll: f32,
+    /// Current reading (percent above offset) that indicates a stall.
+    /// Matches reference firmware
+    pub current_threshold: f32,
+    /// Number of current sensor samples to average for offset calibration.
+    pub calibration_samples: u32,
+    /// Milliseconds between current checks during homing.
+    pub poll_delay_ms: u32,
+    /// Maximum time allowed for homing before timeout (ms).
+    pub timeout_ms: u32,
+}
+
+impl Default for HomingConfig {
+    fn default() -> Self {
+        Self {
+            crawl_mm_per_poll: 0.25,
+            current_threshold: 6.0,
+            calibration_samples: 1000,
+            poll_delay_ms: 10,
+            timeout_ms: 40_000,
+        }
+    }
+}
+
+pub struct StepDirBoard<M: StepDir, C: CurrentSensor, D: DelayNs> {
+    motor: M,
+    current_sensor: C,
+    delay: D,
+    mechanical: &'static MechanicalConfig,
+    homing: HomingConfig,
+}
+
+impl<M: StepDir, C: CurrentSensor, D: DelayNs> StepDirBoard<M, C, D> {
+    pub fn new(
+        motor: M,
+        current_sensor: C,
+        delay: D,
+        mechanical: &'static MechanicalConfig,
+        homing: HomingConfig,
+    ) -> Self {
+        Self {
+            motor,
+            current_sensor,
+            delay,
+            mechanical,
+            homing,
+        }
+    }
+
+    /// Calibrate the current sensor by averaging readings at idle.
+    async fn calibrate_current_offset(&mut self) -> Result<f32, C::Error> {
+        let mut sum: f32 = 0.0;
+        for _ in 0..self.homing.calibration_samples {
+            sum += self.current_sensor.read_percent().await?;
+        }
+        Ok(sum / self.homing.calibration_samples as f32)
+    }
+
+    /// Crawl in one [`Direction`] until a current spike is detected, then back off.
+    async fn crawl_until_stall(
+        &mut self,
+        direction: Direction,
+        offset: f32,
+    ) -> Result<i32, BoardError<M::Error, C::Error>> {
+        let crawl_steps = self.mechanical.mm_to_steps(
+            self.homing.crawl_mm_per_poll as f64,
+            self.motor.steps_per_rev(),
+        );
+        let max_polls = self.homing.timeout_ms / self.homing.poll_delay_ms;
+        let mut position: i32 = 0;
+
+        for _ in 0..max_polls {
+            position += direction as i32 * crawl_steps;
+            self.motor
+                .set_absolute_position(position)
+                .await
+                .map_err(BoardError::Motor)?;
+
+            self.delay.delay_ms(self.homing.poll_delay_ms).await;
+
+            let reading = self
+                .current_sensor
+                .read_percent()
+                .await
+                .map_err(BoardError::CurrentSensor)?;
+            let current = (reading - offset).abs();
+
+            if current > self.homing.current_threshold {
+                info!(
+                    "Stall detected at position {} (current: {:.1}%)",
+                    position, current
+                );
+                return Ok(position);
+            }
+        }
+
+        Err(BoardError::HomingTimeout)
+    }
+}
+
+impl<M, C, D> Board for StepDirBoard<M, C, D>
+where
+    M: StepDir,
+    C: CurrentSensor,
+    D: DelayNs,
+{
+    type Error = BoardError<M::Error, C::Error>;
+
+    async fn enable(&mut self) -> Result<(), Self::Error> {
+        self.motor.enable().await.map_err(BoardError::Motor)
+    }
+
+    async fn disable(&mut self) -> Result<(), Self::Error> {
+        self.motor.disable().await.map_err(BoardError::Motor)
+    }
+
+    async fn home(&mut self) -> Result<(), Self::Error> {
+        info!("Homing started");
+
+        self.motor.enable().await.map_err(BoardError::Motor)?;
+
+        let offset = self
+            .calibrate_current_offset()
+            .await
+            .map_err(BoardError::CurrentSensor)?;
+        info!("Current sensor offset: {:.2}%", offset);
+
+        // Crawl backward (toward home) until stall
+        self.crawl_until_stall(Direction::Forward, offset).await?;
+
+        // Zero at the hard stop — the controller will move to min_position_mm
+        self.motor.reset_position(0);
+
+        info!("Homing complete");
+        Ok(())
+    }
+
+    async fn set_position(&mut self, position_mm: f64) -> Result<(), Self::Error> {
+        let steps = self
+            .mechanical
+            .mm_to_steps(position_mm, self.motor.steps_per_rev());
+        self.motor
+            .set_absolute_position(steps)
+            .await
+            .map_err(BoardError::Motor)
+    }
+
+    async fn set_torque(&mut self, _fraction: f64) -> Result<(), Self::Error> {
+        // Step/dir drivers handle current limiting in hardware.
+        Ok(())
+    }
+
+    async fn position_mm(&mut self) -> Result<f64, Self::Error> {
+        let steps = self
+            .motor
+            .read_absolute_position()
+            .await
+            .map_err(BoardError::Motor)?;
+        Ok(self
+            .mechanical
+            .steps_to_mm(steps, self.motor.steps_per_rev()))
+    }
+
+    async fn tick(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}

--- a/firmware/ossm-reference/.cargo/config.toml
+++ b/firmware/ossm-reference/.cargo/config.toml
@@ -1,0 +1,9 @@
+[build]
+target = "xtensa-esp32-none-elf"
+rustflags = ["-C", "link-arg=-nostartfiles"]
+
+[target.xtensa-esp32-none-elf]
+runner = "espflash flash --monitor"
+
+[unstable]
+build-std = ["alloc", "core"]

--- a/firmware/ossm-reference/Cargo.toml
+++ b/firmware/ossm-reference/Cargo.toml
@@ -1,0 +1,53 @@
+[package]
+name = "ossm-reference"
+version = "0.1.0"
+edition = "2024"
+rust-version = "1.88"
+
+[dependencies]
+ossm = { path = "../../ossm" }
+pattern-engine = { path = "../../features/pattern-engine" }
+m57aim-motor = { path = "../../drivers/m57aim" }
+stepdir-board = { path = "../../boards/stepdir" }
+ble-remote = { path = "../../features/ble-remote", features = [
+    "esp32",
+] }
+
+esp-hal = { version = "~1.0", features = ["log-04", "esp32", "unstable"] }
+
+esp-radio = { version = "0.17.0", default-features = false, features = [
+    "ble",
+    "esp32",
+    "log-04",
+    "unstable",
+] }
+
+esp-rtos = { version = "0.2.0", features = [
+    "log-04",
+    "embassy",
+    "esp-alloc",
+    "esp-radio",
+    "esp32",
+] }
+
+esp-bootloader-esp-idf = { version = "0.4.0", features = ["log-04", "esp32"] }
+
+log = { version = "0.4.27", features = ["release_max_level_info"] }
+
+embassy-executor = { version = "0.9.1", features = ["log"] }
+embassy-time = { version = "0.5.1", features = ["log"] }
+esp-alloc = { version = "0.9.0" }
+esp-backtrace = { version = "0.18.1", features = [
+    "println",
+    "esp32",
+    "panic-handler",
+] }
+esp-println = { version = "0.16.1", features = ["esp32", "log-04"] }
+
+embassy-futures = "0.1"
+embassy-sync = "0.7"
+
+critical-section = "1.2.0"
+nb = "1.1"
+portable-atomic = { version = "1", default-features = false }
+static_cell = "2.1.1"

--- a/firmware/ossm-reference/build.rs
+++ b/firmware/ossm-reference/build.rs
@@ -1,0 +1,96 @@
+fn main() {
+    emit_build_info();
+    linker_be_nice();
+    // make sure linkall.x is the last linker script (otherwise might cause problems with flip-link)
+    println!("cargo:rustc-link-arg=-Tlinkall.x");
+}
+
+fn emit_build_info() {
+    println!("cargo:rustc-env=OSSM_DEVICE={}", std::env::var("CARGO_PKG_NAME").unwrap());
+
+    let commit = std::process::Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .unwrap_or_else(|| "unknown".into());
+    println!("cargo:rustc-env=OSSM_COMMIT_HASH={commit}");
+
+    let release_id = std::env::var("OSSM_RELEASE_ID").unwrap_or_else(|_| "dev".into());
+    println!("cargo:rustc-env=OSSM_RELEASE_ID={release_id}");
+
+    let build_time = std::process::Command::new("date")
+        .args(["-u", "+%Y-%m-%dT%H:%M:%SZ"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .unwrap_or_else(|| "unknown".into());
+    println!("cargo:rustc-env=OSSM_BUILD_TIME={build_time}");
+}
+
+fn linker_be_nice() {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() > 1 {
+        let kind = &args[1];
+        let what = &args[2];
+
+        match kind.as_str() {
+            "undefined-symbol" => match what.as_str() {
+                what if what.starts_with("_defmt_") => {
+                    eprintln!();
+                    eprintln!(
+                        "💡 `defmt` not found - make sure `defmt.x` is added as a linker script and you have included `use defmt_rtt as _;`"
+                    );
+                    eprintln!();
+                }
+                "_stack_start" => {
+                    eprintln!();
+                    eprintln!("💡 Is the linker script `linkall.x` missing?");
+                    eprintln!();
+                }
+                what if what.starts_with("esp_rtos_") => {
+                    eprintln!();
+                    eprintln!(
+                        "💡 `esp-radio` has no scheduler enabled. Make sure you have initialized `esp-rtos` or provided an external scheduler."
+                    );
+                    eprintln!();
+                }
+                "embedded_test_linker_file_not_added_to_rustflags" => {
+                    eprintln!();
+                    eprintln!(
+                        "💡 `embedded-test` not found - make sure `embedded-test.x` is added as a linker script for tests"
+                    );
+                    eprintln!();
+                }
+                "free"
+                | "malloc"
+                | "calloc"
+                | "get_free_internal_heap_size"
+                | "malloc_internal"
+                | "realloc_internal"
+                | "calloc_internal"
+                | "free_internal" => {
+                    eprintln!();
+                    eprintln!(
+                        "💡 Did you forget the `esp-alloc` dependency or didn't enable the `compat` feature on it?"
+                    );
+                    eprintln!();
+                }
+                _ => (),
+            },
+            // we don't have anything helpful for "missing-lib" yet
+            _ => {
+                std::process::exit(1);
+            }
+        }
+
+        std::process::exit(0);
+    }
+
+    println!(
+        "cargo:rustc-link-arg=-Wl,--error-handling-script={}",
+        std::env::current_exe().unwrap().display()
+    );
+}

--- a/firmware/ossm-reference/partitions.csv
+++ b/firmware/ossm-reference/partitions.csv
@@ -1,0 +1,4 @@
+# Name,   Type, SubType, Offset,  Size,    Flags
+nvs,      data, nvs,     0x9000,  0x6000,
+phy_init, data, phy,     0xf000,  0x1000,
+factory,  app,  factory, 0x10000, 0x200000,

--- a/firmware/ossm-reference/rust-toolchain.toml
+++ b/firmware/ossm-reference/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "esp"

--- a/firmware/ossm-reference/src/current_sensor.rs
+++ b/firmware/ossm-reference/src/current_sensor.rs
@@ -1,0 +1,34 @@
+use esp_hal::{
+    Blocking,
+    analog::adc::{Adc, AdcPin},
+    peripherals::{ADC1, GPIO36},
+};
+use ossm::CurrentSensor;
+
+/// Reads motor current draw from an analog pin on ADC1.
+///
+/// ADC1 is used instead of ADC2 because ADC2 conflicts with the WiFi/BLE
+/// radio on ESP32.
+pub struct AdcCurrentSensor {
+    adc: Adc<'static, ADC1<'static>, Blocking>,
+    pin: AdcPin<GPIO36<'static>, ADC1<'static>>,
+}
+
+impl AdcCurrentSensor {
+    pub fn new(adc: Adc<'static, ADC1<'static>, Blocking>, pin: AdcPin<GPIO36<'static>, ADC1<'static>>) -> Self {
+        Self { adc, pin }
+    }
+}
+
+impl CurrentSensor for AdcCurrentSensor {
+    type Error = AdcError;
+
+    async fn read_percent(&mut self) -> Result<f32, Self::Error> {
+        let raw = nb::block!(self.adc.read_oneshot(&mut self.pin)).map_err(|_| AdcError)?;
+        // 12-bit ADC: 0–4095 → 0.0–100.0%
+        Ok(raw as f32 / 4095.0 * 100.0)
+    }
+}
+
+#[derive(Debug)]
+pub struct AdcError;

--- a/firmware/ossm-reference/src/main.rs
+++ b/firmware/ossm-reference/src/main.rs
@@ -1,0 +1,176 @@
+#![no_std]
+#![no_main]
+#![deny(
+    clippy::mem_forget,
+    reason = "mem::forget is generally not safe to do with esp_hal types, especially those \
+    holding buffers for the duration of a data transfer."
+)]
+#![deny(clippy::large_stack_frames)]
+
+mod current_sensor;
+mod step_output;
+
+use embassy_executor::Spawner;
+use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
+use embassy_sync::signal::Signal;
+use embassy_time::Delay;
+use embassy_time::{Duration, Ticker};
+use esp_hal::{Config, init};
+use esp_hal::{
+    analog::adc::{Adc, AdcConfig, Attenuation},
+    gpio::{Level, Output, OutputConfig},
+    interrupt::{Priority, software::SoftwareInterruptControl},
+    rmt::{Rmt, TxChannelConfig, TxChannelCreator},
+    system::Stack,
+    time::Rate,
+    timer::timg::TimerGroup,
+};
+use esp_radio::ble::controller::BleConnector;
+use esp_rtos::embassy::InterruptExecutor;
+use log::info;
+use m57aim_motor::{Motor57AIM, Motor57AIMConfig};
+use ossm::{MechanicalConfig, MotionController, MotionLimits, Ossm, StepDirConfig, StepDirMotor};
+
+use current_sensor::AdcCurrentSensor;
+use step_output::{RMT_CLK_DIVIDER, RmtStepOutput};
+use stepdir_board::{HomingConfig, StepDirBoard};
+
+use pattern_engine::{AnyPattern, PatternEngine};
+use static_cell::StaticCell;
+
+use {esp_backtrace as _, esp_println as _};
+
+extern crate alloc;
+
+esp_bootloader_esp_idf::esp_app_desc!();
+
+const UPDATE_INTERVAL_SECS: f64 = 0.01;
+
+macro_rules! mk_static {
+    ($t:ty, $val:expr) => {{
+        static STATIC_CELL: StaticCell<$t> = StaticCell::new();
+        STATIC_CELL.init($val)
+    }};
+}
+
+type ConcreteMotor =
+    Motor57AIM<StepDirMotor<RmtStepOutput, Output<'static>, Output<'static>>, Delay>;
+type ConcreteBoard = StepDirBoard<ConcreteMotor, AdcCurrentSensor, Delay>;
+
+static OSSM: Ossm = Ossm::new();
+static PATTERNS: PatternEngine = PatternEngine::new(&OSSM);
+
+static EXECUTOR_CORE_1: StaticCell<InterruptExecutor<2>> = StaticCell::new();
+// ESP32 DRAM is tighter than ESP32-S3. 16KB stack is needed for ruckig's
+// trajectory calculator (heavy float math). 64KB heap is needed for the BLE
+// radio stack's internal allocations. ESP-NOW was dropped to fit within
+// the ESP32's memory constraints.
+static APP_CORE_STACK: StaticCell<Stack<16384>> = StaticCell::new();
+static MOTION_READY: Signal<CriticalSectionRawMutex, bool> = Signal::new();
+
+#[embassy_executor::task]
+async fn motion_task(mut controller: MotionController<'static, ConcreteBoard>) {
+    let interval_us = (UPDATE_INTERVAL_SECS * 1_000_000.0) as u64;
+    let mut ticker = Ticker::every(Duration::from_micros(interval_us));
+
+    loop {
+        if let Err(e) = controller.update().await {
+            log::error!("Motion controller fault: {:?}", e);
+        }
+        ticker.next().await;
+    }
+}
+
+#[esp_rtos::main]
+async fn main(spawner: Spawner) {
+    ossm::logging::init(log::LevelFilter::Info, |line| {
+        esp_println::println!("{}", line);
+    });
+
+    ossm::build_info!();
+
+    let p = init(Config::default());
+
+    esp_alloc::heap_allocator!(size: 64 * 1024);
+
+    let timg0 = TimerGroup::new(p.TIMG0);
+    esp_rtos::start(timg0.timer0);
+
+    let rmt = Rmt::new(p.RMT, Rate::from_mhz(80)).expect("Failed to initialize RMT");
+    let tx_config = TxChannelConfig::default().with_clk_divider(RMT_CLK_DIVIDER);
+    let rmt_channel = rmt
+        .channel0
+        .configure_tx(p.GPIO14, tx_config)
+        .expect("Failed to configure RMT TX channel");
+
+    let step_output = RmtStepOutput::new(rmt_channel);
+    let dir_pin = Output::new(p.GPIO27, Level::Low, OutputConfig::default());
+    let enable_pin = Output::new(p.GPIO26, Level::High, OutputConfig::default());
+
+    let step_dir_config = StepDirConfig::default();
+    let step_dir_motor = StepDirMotor::new(step_output, dir_pin, enable_pin, step_dir_config);
+
+    let motor = Motor57AIM::new(step_dir_motor, Motor57AIMConfig::default(), Delay);
+
+    let mut adc1_config = AdcConfig::new();
+    let adc_pin = adc1_config.enable_pin(p.GPIO36, Attenuation::_11dB);
+    let adc1 = Adc::new(p.ADC1, adc1_config);
+    let current_sensor = AdcCurrentSensor::new(adc1, adc_pin);
+
+    static MECHANICAL: MechanicalConfig = MechanicalConfig {
+        pulley_teeth: 20,
+        belt_pitch_mm: 2.0,
+    };
+    let limits = MotionLimits::default();
+
+    let board = StepDirBoard::new(
+        motor,
+        current_sensor,
+        Delay,
+        &MECHANICAL,
+        HomingConfig::default(),
+    );
+    let controller = OSSM.controller(board, limits.clone(), UPDATE_INTERVAL_SECS);
+
+    let sw_int = SoftwareInterruptControl::new(p.SW_INTERRUPT);
+    let app_core_stack = APP_CORE_STACK.init(Stack::new());
+
+    let second_core = move || {
+        let executor = InterruptExecutor::new(sw_int.software_interrupt2);
+        let executor = EXECUTOR_CORE_1.init(executor);
+        let spawner = executor.start(Priority::Priority2);
+
+        spawner.spawn(motion_task(controller)).unwrap();
+
+        MOTION_READY.signal(true);
+
+        loop {}
+    };
+
+    esp_rtos::start_second_core(
+        p.CPU_CTRL,
+        sw_int.software_interrupt0,
+        sw_int.software_interrupt1,
+        app_core_stack,
+        second_core,
+    );
+
+    MOTION_READY.wait().await;
+
+    info!(
+        "Motion task started on core 1 at {}ms interval",
+        UPDATE_INTERVAL_SECS * 1000.0
+    );
+
+    let radio = &*mk_static!(
+        esp_radio::Controller<'static>,
+        esp_radio::init().expect("Failed to initialize radio controller")
+    );
+
+    let connector =
+        BleConnector::new(radio, p.BT, Default::default()).expect("Could not create BleConnector");
+    ble_remote::start(&spawner, connector, &PATTERNS);
+
+    let mut pattern_runner = PATTERNS.runner(AnyPattern::all_builtin());
+    pattern_runner.run(Delay).await;
+}

--- a/firmware/ossm-reference/src/step_output.rs
+++ b/firmware/ossm-reference/src/step_output.rs
@@ -1,0 +1,107 @@
+use core::fmt::Debug;
+
+use alloc::fmt;
+use esp_hal::{
+    Blocking,
+    gpio::Level,
+    rmt::{Channel, PulseCode, Tx},
+};
+use ossm::StepOutput;
+
+/// RMT clock divider. With an statically set 80 MHz base clock,
+/// divider=4 gives 20 MHz (50 ns per tick).
+pub const RMT_CLK_DIVIDER: u8 = 4;
+
+/// Step pulse width in RMT ticks. At 50 ns/tick, 20 ticks = 1 µs per half.
+/// Full step period = 2 µs → max 500 kHz step rate.
+/// Matches FastAccelStepper's minimum 1 µs pulse width used by the reference firmware.
+const STEP_PULSE_TICKS: u16 = 20;
+
+/// Maximum number of step pulses per RMT transmission batch.
+/// The ESP32 has 512 × 32-bit entries shared across 8 channels (64 per channel).
+/// We use 63 pulses + 1 end marker per batch.
+const STEP_BATCH_SIZE: usize = 63;
+
+/// Generates step pulses via the ESP32 RMT (Remote Control Transceiver) peripheral.
+///
+/// The RMT is a hardware pulse generator. You give it an array of
+/// [`PulseCode`]s — each one describes two pin-level/duration pairs — and it
+/// drives the GPIO autonomously. No CPU involvement while pulses are in flight.
+///
+/// Each `PulseCode` encodes one complete step pulse:
+/// ```text
+/// PulseCode::new(High, 20, Low, 20)
+///   → pin HIGH for 20 ticks (1 µs), then LOW for 20 ticks (1 µs)
+///   → one step = 2 µs total
+/// ```
+///
+/// The RMT has limited on-chip RAM (64 entries per channel on ESP32), so large
+/// step counts are sent in batches of 63 + end marker. The hardware supports
+/// wrap-around (ping-pong) mode to refill one half while transmitting the
+/// other, but esp-hal 1.0.0 doesn't expose this on ESP32 — so we batch
+/// sequentially with a brief CPU gap (~µs) between batches. In practice this
+/// gap is negligible and doesn't affect motor behaviour.
+/// This also matches the reference firmware's approach of sending steps.
+pub struct RmtStepOutput {
+    channel: Option<Channel<'static, Blocking, Tx>>,
+    pulse: PulseCode,
+}
+
+impl RmtStepOutput {
+    pub fn new(channel: Channel<'static, Blocking, Tx>) -> Self {
+        let pulse = PulseCode::new(Level::High, STEP_PULSE_TICKS, Level::Low, STEP_PULSE_TICKS);
+        Self {
+            channel: Some(channel),
+            pulse,
+        }
+    }
+}
+
+pub enum RmtError {
+    Rmt(esp_hal::rmt::Error),
+    ChannelInUse,
+}
+
+impl Debug for RmtError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Rmt(e) => write!(f, "Rmt({:?})", e),
+            Self::ChannelInUse => write!(f, "ChannelInUse"),
+        }
+    }
+}
+
+impl StepOutput for RmtStepOutput {
+    type Error = RmtError;
+
+    /// Send the specified number of step pulses, if greater than the
+    /// batch size, in sequential batches of 63 + end marker. The RMT transmits
+    /// each batch autonomously while the CPU prepares the next batch.
+    async fn step(&mut self, count: u32) -> Result<(), Self::Error> {
+        let mut remaining = count as usize;
+        let mut ch = self.channel.take().ok_or(RmtError::ChannelInUse)?;
+
+        while remaining > 0 {
+            let batch = remaining.min(STEP_BATCH_SIZE);
+            remaining -= batch;
+
+            let mut buf = [PulseCode::end_marker(); STEP_BATCH_SIZE + 1];
+            for entry in buf.iter_mut().take(batch) {
+                *entry = self.pulse;
+            }
+            buf[batch] = PulseCode::end_marker();
+
+            let tx = ch.transmit(&buf[..batch + 1]).map_err(RmtError::Rmt)?;
+            ch = match tx.wait() {
+                Ok(c) => c,
+                Err((e, c)) => {
+                    self.channel = Some(c);
+                    return Err(RmtError::Rmt(e));
+                }
+            };
+        }
+
+        self.channel = Some(ch);
+        Ok(())
+    }
+}

--- a/justfile
+++ b/justfile
@@ -32,6 +32,15 @@ build-seeed-xiao:
 flash-seeed-xiao:
     cargo +esp run --release
 
+# OSSM Reference (ESP32)
+[working-directory: 'firmware/ossm-reference']
+build-ossm-reference:
+    cargo +esp build --release
+
+[working-directory: 'firmware/ossm-reference']
+flash-ossm-reference:
+    cargo +esp run --release
+
 
 # WASM Simulator
 build-wasm:
@@ -44,7 +53,7 @@ dev-patterns: build-wasm
 
 # All
 [parallel]
-build-all: build-ossm-alt build-waveshare build-seeed-xiao build-wasm
+build-all: build-ossm-alt build-waveshare build-seeed-xiao build-ossm-reference build-wasm
 
 # Check that all required tools are installed
 [unix]

--- a/ossm/src/board.rs
+++ b/ossm/src/board.rs
@@ -55,6 +55,9 @@ pub trait Board {
     /// 1. Performing the homing motion (however the hardware supports it)
     /// 2. Zeroing its internal position reference
     /// 3. Configuring the motor for maximum tracking performance afterward
+    ///
+    /// The motion controller will move the motor to `min_position_mm` after
+    /// homing completes — the board does not need to handle backoff.
     async fn home(&mut self) -> Result<(), Self::Error>;
 
     /// Command the motor to a position immediately.

--- a/ossm/src/lib.rs
+++ b/ossm/src/lib.rs
@@ -17,7 +17,7 @@ use command::OssmChannels;
 pub use limits::MotionLimits;
 pub use mechanical::MechanicalConfig;
 pub use motion::MotionController;
-pub use motor::{Motor, Rs485Motor, SelfHoming, StepDir};
+pub use motor::{CurrentSensor, Motor, Rs485Motor, SelfHoming, StepDir};
 pub use transport::{
     Modbus, ModbusTransport, Rs485, Rs485ModbusTransport, StepDirConfig, StepDirError,
     StepDirMotor, StepOutput, TransportError,

--- a/ossm/src/motor/current_sensor.rs
+++ b/ossm/src/motor/current_sensor.rs
@@ -1,0 +1,12 @@
+use core::fmt::Debug;
+
+/// A sensor that can read motor current draw.
+///
+/// Used by the stepdir board for sensorless homing.
+#[allow(async_fn_in_trait)]
+pub trait CurrentSensor {
+    type Error: Debug;
+
+    /// Read the current draw as a percentage of the sensor's full range.
+    async fn read_percent(&mut self) -> Result<f32, Self::Error>;
+}

--- a/ossm/src/motor/mod.rs
+++ b/ossm/src/motor/mod.rs
@@ -1,7 +1,9 @@
+mod current_sensor;
 mod rs485;
 mod self_homing;
 mod step_dir;
 
+pub use current_sensor::CurrentSensor;
 pub use rs485::Rs485Motor;
 pub use self_homing::SelfHoming;
 pub use step_dir::StepDir;


### PR DESCRIPTION
## Problem

Most users have the ossm-reference board which supports step/dir out of the box.

## Solution

Ideally we would provide mods to allow it to support rs485, but for now we can support stepdir in the same way the reference firmware does

## Testing

I've flashed an ossm-reference and tested the homing sequence, patterns and power draw. Memory was an issue, I've disabled ESP-now functionality for this build.

This is heavily based on #26

This closes #41 