### PR TITLE
feat(ossm): Add retry logic to uart

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -379,6 +379,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "embassy-sync"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bbd85cf5a5ae56bdf26f618364af642d1d0a4e245cdd75cd9aabda382f65a81"
+dependencies = [
+ "cfg-if",
+ "critical-section",
+ "embedded-io-async 0.7.0",
+ "futures-core",
+ "futures-sink",
+ "heapless 0.9.2",
+]
+
+[[package]]
 name = "embassy-time"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -414,12 +428,12 @@ dependencies = [
 
 [[package]]
 name = "embassy-usb-synopsys-otg"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "288751f8eaa44a5cf2613f13cee0ca8e06e6638cb96e897e6834702c79084b23"
+checksum = "cbe46f4083109c7ea12a03ca61095d1e87c76fec52c7ca9ee06a42935606dacb"
 dependencies = [
  "critical-section",
- "embassy-sync 0.7.2",
+ "embassy-sync 0.8.0",
  "embassy-usb-driver",
 ]
 
@@ -867,9 +881,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heapless"
@@ -911,9 +925,9 @@ checksum = "9007da9cacbd3e6343da136e98b0d2df013f553d35bdec8b518f07bea768e19c"
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -930,9 +944,9 @@ dependencies = [
 
 [[package]]
 name = "instability"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357b7205c6cd18dd2c86ed312d1e70add149aea98e7ef72b9fdf0270e555c11d"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
 dependencies = [
  "darling 0.23.0",
  "indoc",
@@ -943,15 +957,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.92"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc4c90f45aa2e6eacbe8645f77fdea542ac97a494bcd117a67df9ff4d611f995"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -959,9 +973,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libm"
@@ -1052,9 +1066,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "ossm"
@@ -1065,7 +1079,7 @@ dependencies = [
  "embassy-time",
  "embedded-hal 1.0.0",
  "embedded-hal-async",
- "embedded-io 0.7.1",
+ "embedded-io 0.6.1",
  "heapless 0.9.2",
  "log",
  "rmodbus",
@@ -1466,18 +1480,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.0.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.25.3+spec-1.1.0"
+version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0a07913e63758bc95142d9863a5a45173b71515e68b690cad70cf99c3255ce1"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -1487,9 +1501,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.9+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow",
 ]
@@ -1541,9 +1555,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -1563,9 +1577,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.22.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1591,9 +1605,9 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.115"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6523d69017b7633e396a89c5efab138161ed5aafcbc8d3e5c5a42ae38f50495a"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1604,9 +1618,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.115"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3a6c758eb2f701ed3d052ff5737f5bfe6614326ea7f3bbac7156192dc32e67"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1614,9 +1628,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.115"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "921de2737904886b52bcbb237301552d05969a6f9c40d261eb0533c8b055fedf"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1627,9 +1641,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.115"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a93e946af942b58934c604527337bad9ae33ba1d5c6900bbb41c2c07c2364a93"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -1660,9 +1674,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.14"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 dependencies = [
  "memchr",
 ]
@@ -1700,18 +1714,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/bindings/web-simulator/Cargo.lock
+++ b/bindings/web-simulator/Cargo.lock
@@ -165,18 +165,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
-name = "embedded-io"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eb1aa714776b75c7e67e1da744b81a129b3ff919c8712b5e1b32252c1f07cc7"
-
-[[package]]
 name = "embedded-io-async"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ff09972d4073aa8c299395be75161d582e7629cd663171d62af73c8d50dba3f"
 dependencies = [
- "embedded-io 0.6.1",
+ "embedded-io",
 ]
 
 [[package]]
@@ -402,7 +396,7 @@ dependencies = [
  "embassy-time",
  "embedded-hal 1.0.0",
  "embedded-hal-async",
- "embedded-io 0.7.1",
+ "embedded-io",
  "heapless 0.9.2",
  "log",
  "rmodbus",

--- a/firmware/ossm-alt/Cargo.lock
+++ b/firmware/ossm-alt/Cargo.lock
@@ -1094,9 +1094,9 @@ checksum = "9007da9cacbd3e6343da136e98b0d2df013f553d35bdec8b518f07bea768e19c"
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -1156,9 +1156,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.92"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc4c90f45aa2e6eacbe8645f77fdea542ac97a494bcd117a67df9ff4d611f995"
+checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1166,9 +1166,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "libm"
@@ -1278,7 +1278,7 @@ dependencies = [
  "embassy-time",
  "embedded-hal 1.0.0",
  "embedded-hal-async",
- "embedded-io 0.7.1",
+ "embedded-io 0.6.1",
  "heapless 0.9.2",
  "log",
  "rmodbus",
@@ -1317,7 +1317,9 @@ dependencies = [
 name = "ossm-esp"
 version = "0.1.0"
 dependencies = [
+ "embedded-io 0.6.1",
  "esp-hal",
+ "ossm",
 ]
 
 [[package]]
@@ -1729,18 +1731,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.25.8+spec-1.1.0"
+version = "0.25.10+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16bff38f1d86c47f9ff0647e6838d7bb362522bdf44006c7068c2b1e606f1f3c"
+checksum = "a82418ca169e235e6c399a84e395ab6debeb3bc90edc959bf0f48647c6a32d1b"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -1750,9 +1752,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow",
 ]
@@ -1866,9 +1868,9 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.115"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6523d69017b7633e396a89c5efab138161ed5aafcbc8d3e5c5a42ae38f50495a"
+checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1879,9 +1881,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.115"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3a6c758eb2f701ed3d052ff5737f5bfe6614326ea7f3bbac7156192dc32e67"
+checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1889,9 +1891,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.115"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "921de2737904886b52bcbb237301552d05969a6f9c40d261eb0533c8b055fedf"
+checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1902,9 +1904,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.115"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a93e946af942b58934c604527337bad9ae33ba1d5c6900bbb41c2c07c2364a93"
+checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
 dependencies = [
  "unicode-ident",
 ]
@@ -1935,9 +1937,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 dependencies = [
  "memchr",
 ]

--- a/firmware/ossm-alt/Cargo.toml
+++ b/firmware/ossm-alt/Cargo.toml
@@ -51,6 +51,7 @@ esp-backtrace = { version = "0.18.1", features = [
     "println",
     "esp32s3",
     "panic-handler",
+    "halt-cores",
 ] }
 esp-println = { version = "0.16.1", features = ["esp32s3", "log-04"] }
 

--- a/firmware/ossm-alt/src/main.rs
+++ b/firmware/ossm-alt/src/main.rs
@@ -14,7 +14,6 @@ use embassy_sync::signal::Signal;
 use embassy_time::Delay;
 use embassy_time::{Duration, Ticker};
 use esp_hal::{
-    Blocking,
     interrupt::{Priority, software::SoftwareInterruptControl},
     system::Stack,
     timer::timg::TimerGroup,
@@ -26,6 +25,7 @@ use esp_rtos::embassy::InterruptExecutor;
 use log::info;
 use m57aim_motor::{DEFAULT_DEVICE_ADDR, Modbus, Motor57AIM, Motor57AIMConfig, TARGET_BAUD_RATE};
 use ossm::{MechanicalConfig, MotionController, MotionLimits, Ossm};
+use ossm_esp::uart::NonBlockingUart;
 
 use ossm_m5_remote::RemoteConfig;
 use rs485_board::{Rs485Board, Rs485ModbusTransport};
@@ -48,7 +48,7 @@ macro_rules! mk_static {
     }};
 }
 
-type ConcreteTransport = Rs485ModbusTransport<Uart<'static, Blocking>, Delay>;
+type ConcreteTransport = Rs485ModbusTransport<NonBlockingUart<'static>, Delay>;
 type ConcreteMotor = Motor57AIM<Modbus<ConcreteTransport>, Delay>;
 type ConcreteBoard = Rs485Board<ConcreteMotor>;
 
@@ -95,7 +95,7 @@ async fn main(spawner: Spawner) {
 
     unsafe { ossm_esp::rs485::enable_uart1_rs485(p.GPIO11) };
 
-    let transport = Rs485ModbusTransport::new(uart, Delay);
+    let transport = Rs485ModbusTransport::new(NonBlockingUart(uart), Delay);
     let motor = Motor57AIM::new(
         Modbus::new(transport, DEFAULT_DEVICE_ADDR),
         Motor57AIMConfig::default(),

--- a/firmware/ossm-reference/Cargo.lock
+++ b/firmware/ossm-reference/Cargo.lock
@@ -1056,9 +1056,9 @@ checksum = "9007da9cacbd3e6343da136e98b0d2df013f553d35bdec8b518f07bea768e19c"
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -1118,9 +1118,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.92"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc4c90f45aa2e6eacbe8645f77fdea542ac97a494bcd117a67df9ff4d611f995"
+checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1128,9 +1128,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "libm"
@@ -1231,7 +1231,7 @@ dependencies = [
  "embassy-time",
  "embedded-hal 1.0.0",
  "embedded-hal-async",
- "embedded-io 0.7.1",
+ "embedded-io 0.6.1",
  "heapless 0.9.2",
  "log",
  "rmodbus",
@@ -1677,18 +1677,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.25.8+spec-1.1.0"
+version = "0.25.10+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16bff38f1d86c47f9ff0647e6838d7bb362522bdf44006c7068c2b1e606f1f3c"
+checksum = "a82418ca169e235e6c399a84e395ab6debeb3bc90edc959bf0f48647c6a32d1b"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -1698,9 +1698,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow",
 ]
@@ -1804,9 +1804,9 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.115"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6523d69017b7633e396a89c5efab138161ed5aafcbc8d3e5c5a42ae38f50495a"
+checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1817,9 +1817,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.115"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3a6c758eb2f701ed3d052ff5737f5bfe6614326ea7f3bbac7156192dc32e67"
+checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1827,9 +1827,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.115"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "921de2737904886b52bcbb237301552d05969a6f9c40d261eb0533c8b055fedf"
+checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1840,9 +1840,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.115"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a93e946af942b58934c604527337bad9ae33ba1d5c6900bbb41c2c07c2364a93"
+checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
 dependencies = [
  "unicode-ident",
 ]
@@ -1873,9 +1873,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 dependencies = [
  "memchr",
 ]

--- a/firmware/ossm-reference/Cargo.toml
+++ b/firmware/ossm-reference/Cargo.toml
@@ -45,6 +45,7 @@ esp-backtrace = { version = "0.18.1", features = [
     "println",
     "esp32",
     "panic-handler",
+    "halt-cores",
 ] }
 esp-println = { version = "0.16.1", features = ["esp32", "log-04"] }
 

--- a/firmware/seeed-xiao/Cargo.lock
+++ b/firmware/seeed-xiao/Cargo.lock
@@ -1094,9 +1094,9 @@ checksum = "9007da9cacbd3e6343da136e98b0d2df013f553d35bdec8b518f07bea768e19c"
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -1278,7 +1278,7 @@ dependencies = [
  "embassy-time",
  "embedded-hal 1.0.0",
  "embedded-hal-async",
- "embedded-io 0.7.1",
+ "embedded-io 0.6.1",
  "heapless 0.9.2",
  "log",
  "rmodbus",
@@ -1289,7 +1289,9 @@ dependencies = [
 name = "ossm-esp"
 version = "0.1.0"
 dependencies = [
+ "embedded-io 0.6.1",
  "esp-hal",
+ "ossm",
 ]
 
 [[package]]
@@ -1738,9 +1740,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.9+spec-1.1.0"
+version = "0.25.10+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da053d28fe57e2c9d21b48261e14e7b4c8b670b54d2c684847b91feaf4c7dac5"
+checksum = "a82418ca169e235e6c399a84e395ab6debeb3bc90edc959bf0f48647c6a32d1b"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -1750,9 +1752,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.1+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39ca317ebc49f06bd748bfba29533eac9485569dc9bf80b849024b025e814fb9"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow",
 ]

--- a/firmware/seeed-xiao/Cargo.toml
+++ b/firmware/seeed-xiao/Cargo.toml
@@ -49,6 +49,7 @@ esp-backtrace = { version = "0.18.1", features = [
     "println",
     "esp32s3",
     "panic-handler",
+    "halt-cores",
 ] }
 esp-println = { version = "0.16.1", features = ["esp32s3", "log-04"] }
 

--- a/firmware/seeed-xiao/src/main.rs
+++ b/firmware/seeed-xiao/src/main.rs
@@ -14,7 +14,6 @@ use embassy_sync::signal::Signal;
 use embassy_time::Delay;
 use embassy_time::{Duration, Ticker};
 use esp_hal::{
-    Blocking,
     interrupt::{Priority, software::SoftwareInterruptControl},
     system::Stack,
     timer::timg::TimerGroup,
@@ -27,6 +26,7 @@ use log::info;
 use m57aim_motor::{DEFAULT_DEVICE_ADDR, Modbus, Motor57AIM, Motor57AIMConfig, TARGET_BAUD_RATE};
 use ossm::{MechanicalConfig, MotionController, MotionLimits, Ossm};
 
+use ossm_esp::uart::NonBlockingUart;
 use ossm_m5_remote::RemoteConfig;
 use rs485_board::{Rs485Board, Rs485ModbusTransport};
 
@@ -48,7 +48,8 @@ macro_rules! mk_static {
     }};
 }
 
-type ConcreteTransport = Rs485ModbusTransport<Uart<'static, Blocking>, Delay>;
+type ConcreteTransport =
+    Rs485ModbusTransport<NonBlockingUart<'static>, Delay>;
 type ConcreteMotor = Motor57AIM<Modbus<ConcreteTransport>, Delay>;
 type ConcreteBoard = Rs485Board<ConcreteMotor>;
 
@@ -93,7 +94,7 @@ async fn main(spawner: Spawner) {
 
     unsafe { ossm_esp::rs485::enable_uart1_rs485(p.GPIO3) };
 
-    let transport = Rs485ModbusTransport::new(uart, Delay);
+    let transport = Rs485ModbusTransport::new(NonBlockingUart(uart), Delay);
     let motor = Motor57AIM::new(
         Modbus::new(transport, DEFAULT_DEVICE_ADDR),
         Motor57AIMConfig::default(),

--- a/firmware/waveshare/Cargo.lock
+++ b/firmware/waveshare/Cargo.lock
@@ -1094,9 +1094,9 @@ checksum = "9007da9cacbd3e6343da136e98b0d2df013f553d35bdec8b518f07bea768e19c"
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -1156,9 +1156,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.92"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc4c90f45aa2e6eacbe8645f77fdea542ac97a494bcd117a67df9ff4d611f995"
+checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1166,9 +1166,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "libm"
@@ -1278,7 +1278,7 @@ dependencies = [
  "embassy-time",
  "embedded-hal 1.0.0",
  "embedded-hal-async",
- "embedded-io 0.7.1",
+ "embedded-io 0.6.1",
  "heapless 0.9.2",
  "log",
  "rmodbus",
@@ -1289,7 +1289,9 @@ dependencies = [
 name = "ossm-esp"
 version = "0.1.0"
 dependencies = [
+ "embedded-io 0.6.1",
  "esp-hal",
+ "ossm",
 ]
 
 [[package]]
@@ -1701,18 +1703,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.25.8+spec-1.1.0"
+version = "0.25.10+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16bff38f1d86c47f9ff0647e6838d7bb362522bdf44006c7068c2b1e606f1f3c"
+checksum = "a82418ca169e235e6c399a84e395ab6debeb3bc90edc959bf0f48647c6a32d1b"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -1722,9 +1724,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow",
 ]
@@ -1838,9 +1840,9 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.115"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6523d69017b7633e396a89c5efab138161ed5aafcbc8d3e5c5a42ae38f50495a"
+checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1851,9 +1853,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.115"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3a6c758eb2f701ed3d052ff5737f5bfe6614326ea7f3bbac7156192dc32e67"
+checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1861,9 +1863,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.115"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "921de2737904886b52bcbb237301552d05969a6f9c40d261eb0533c8b055fedf"
+checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1874,9 +1876,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.115"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a93e946af942b58934c604527337bad9ae33ba1d5c6900bbb41c2c07c2364a93"
+checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
 dependencies = [
  "unicode-ident",
 ]
@@ -1935,9 +1937,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 dependencies = [
  "memchr",
 ]

--- a/firmware/waveshare/Cargo.toml
+++ b/firmware/waveshare/Cargo.toml
@@ -51,6 +51,7 @@ esp-backtrace = { version = "0.18.1", features = [
     "println",
     "esp32s3",
     "panic-handler",
+    "halt-cores",
 ] }
 esp-println = { version = "0.16.1", features = ["esp32s3", "log-04"] }
 

--- a/firmware/waveshare/src/main.rs
+++ b/firmware/waveshare/src/main.rs
@@ -14,7 +14,6 @@ use embassy_sync::signal::Signal;
 use embassy_time::Delay;
 use embassy_time::{Duration, Ticker};
 use esp_hal::{
-    Blocking,
     interrupt::{Priority, software::SoftwareInterruptControl},
     system::Stack,
     timer::timg::TimerGroup,
@@ -27,6 +26,7 @@ use log::info;
 use m57aim_motor::{DEFAULT_DEVICE_ADDR, Modbus, Motor57AIM, Motor57AIMConfig, TARGET_BAUD_RATE};
 use ossm::{MechanicalConfig, MotionController, MotionLimits, Ossm};
 
+use ossm_esp::uart::NonBlockingUart;
 use ossm_m5_remote::RemoteConfig;
 use rs485_board::{Rs485Board, Rs485ModbusTransport};
 
@@ -48,7 +48,8 @@ macro_rules! mk_static {
     }};
 }
 
-type ConcreteTransport = Rs485ModbusTransport<Uart<'static, Blocking>, Delay>;
+type ConcreteTransport =
+    Rs485ModbusTransport<NonBlockingUart<'static>, Delay>;
 type ConcreteMotor = Motor57AIM<Modbus<ConcreteTransport>, Delay>;
 type ConcreteBoard = Rs485Board<ConcreteMotor>;
 
@@ -95,7 +96,7 @@ async fn main(spawner: Spawner) {
 
     unsafe { ossm_esp::rs485::enable_uart1_rs485(p.GPIO21) };
 
-    let transport = Rs485ModbusTransport::new(uart, Delay);
+    let transport = Rs485ModbusTransport::new(NonBlockingUart(uart), Delay);
     let motor = Motor57AIM::new(
         Modbus::new(transport, DEFAULT_DEVICE_ADDR),
         Motor57AIMConfig::default(),

--- a/ossm-esp/Cargo.lock
+++ b/ossm-esp/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -51,6 +57,21 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
 name = "critical-section"
@@ -240,6 +261,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "embassy-time"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "592b0c143ec626e821d4d90da51a2bd91d559d6c442b7c74a47d368c9e23d97a"
+dependencies = [
+ "cfg-if",
+ "critical-section",
+ "document-features",
+ "embassy-time-driver",
+ "embedded-hal 0.2.7",
+ "embedded-hal 1.0.0",
+ "embedded-hal-async",
+ "futures-core",
+]
+
+[[package]]
+name = "embassy-time-driver"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ee71af1b3a0deaa53eaf2d39252f83504c853646e472400b763060389b9fcc9"
+dependencies = [
+ "document-features",
+]
+
+[[package]]
 name = "embassy-usb-driver"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -388,7 +434,6 @@ dependencies = [
  "bitflags",
  "bytemuck",
  "cfg-if",
- "critical-section",
  "delegate",
  "digest",
  "document-features",
@@ -408,16 +453,9 @@ dependencies = [
  "esp-config",
  "esp-hal-procmacros",
  "esp-metadata-generated",
- "esp-riscv-rt",
  "esp-rom-sys",
  "esp-sync",
  "esp-synopsys-usb-otg",
- "esp32",
- "esp32c2",
- "esp32c3",
- "esp32c6",
- "esp32h2",
- "esp32s2",
  "esp32s3",
  "fugit",
  "instability",
@@ -430,7 +468,6 @@ dependencies = [
  "strum",
  "ufmt-write",
  "xtensa-lx",
- "xtensa-lx-rt",
 ]
 
 [[package]]
@@ -453,17 +490,6 @@ name = "esp-metadata-generated"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a93e39c8ad8d390d248dc7b9f4b59a873f313bf535218b8e2351356972399e3"
-
-[[package]]
-name = "esp-riscv-rt"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "502744a5b1e7268d27fd2a4e56ad45efe42ead517d6c517a6961540de949b0ee"
-dependencies = [
- "document-features",
- "riscv",
- "riscv-rt",
-]
 
 [[package]]
 name = "esp-rom-sys"
@@ -501,66 +527,6 @@ dependencies = [
  "embedded-hal 0.2.7",
  "ral-registers",
  "usb-device",
- "vcell",
-]
-
-[[package]]
-name = "esp32"
-version = "0.39.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b76170a463d18f888a1ad258031901036fd827a9ef126733053ba5f8739fb0c8"
-dependencies = [
- "critical-section",
- "vcell",
-]
-
-[[package]]
-name = "esp32c2"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e62cf8932966b8d445b6f1832977b468178f0a84effb2e9fda89f60c24d45aa3"
-dependencies = [
- "critical-section",
- "vcell",
-]
-
-[[package]]
-name = "esp32c3"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "356af3771d0d6536c735bf71136594f4d1cbb506abf6e0c51a6639e9bf4e7988"
-dependencies = [
- "critical-section",
- "vcell",
-]
-
-[[package]]
-name = "esp32c6"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f5e511df672d79cd63365c92045135e01ba952b6bddd25b660baff5e1110f6b"
-dependencies = [
- "critical-section",
- "vcell",
-]
-
-[[package]]
-name = "esp32h2"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed4a50bbd1380931e095e0973b9b12f782a9c481f2edf1f7c42e7eb4ff736d6d"
-dependencies = [
- "critical-section",
- "vcell",
-]
-
-[[package]]
-name = "esp32s2"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98574d4c577fbe888fe3e6df7fc80d25a05624d9998f7d7de1500ae21fcca78f"
-dependencies = [
- "critical-section",
  "vcell",
 ]
 
@@ -682,6 +648,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
+name = "ieee754"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9007da9cacbd3e6343da136e98b0d2df013f553d35bdec8b518f07bea768e19c"
+
+[[package]]
 name = "indexmap"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -720,10 +692,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "litrs"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "memchr"
@@ -753,6 +737,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -765,10 +750,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "ossm"
+version = "0.1.0"
+dependencies = [
+ "crc",
+ "embassy-sync 0.7.2",
+ "embassy-time",
+ "embedded-hal 1.0.0",
+ "embedded-hal-async",
+ "embedded-io 0.6.1",
+ "heapless 0.9.2",
+ "log",
+ "rmodbus",
+ "rsruckig",
+]
+
+[[package]]
 name = "ossm-esp"
 version = "0.1.0"
 dependencies = [
+ "embedded-io 0.6.1",
  "esp-hal",
+ "ossm",
 ]
 
 [[package]]
@@ -865,33 +868,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8188909339ccc0c68cfb5a04648313f09621e8b87dc03095454f1a11f6c5d436"
 
 [[package]]
-name = "riscv-rt"
-version = "0.16.0"
+name = "rmodbus"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d07b9f3a0eff773fc4df11f44ada4fa302e529bff4b7fe7e6a4b98a65ce9174"
+checksum = "ae086fe401655097112f1bd988012c0334d19b0c495128b256f1506873c6ba8f"
 dependencies = [
- "riscv",
- "riscv-pac",
- "riscv-rt-macros",
- "riscv-target-parser",
+ "heapless 0.9.2",
+ "ieee754",
 ]
 
 [[package]]
-name = "riscv-rt-macros"
-version = "0.6.1"
+name = "rsruckig"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "def519ddeeb5e43c2b4fc3952c27b3a86782fc05192f322b2309125cd85b1fc3"
+checksum = "d00d1462c086d22c24d51440ae918a7a173dede71463bd9afd7d0e958dfe0ca5"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "arrayvec",
+ "num-traits",
+ "thiserror",
 ]
-
-[[package]]
-name = "riscv-target-parser"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1376b15f3ff160e9b1e8ea564ce427f2f6fcf77528cc0a8bf405cb476f9cea7"
 
 [[package]]
 name = "rustversion"
@@ -1017,6 +1012,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1138,26 +1153,4 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e012d667b0aa6d2592ace8ef145a98bff3e76cca7a644f4181ecd7a916ed289b"
 dependencies = [
  "critical-section",
-]
-
-[[package]]
-name = "xtensa-lx-rt"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8709f037fb123fe7ff146d2bce86f9dc0dfc53045c016bfd9d703317b6502845"
-dependencies = [
- "document-features",
- "xtensa-lx",
- "xtensa-lx-rt-proc-macros",
-]
-
-[[package]]
-name = "xtensa-lx-rt-proc-macros"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96fb42cd29c42f8744c74276e9f5bee7b06685bbe5b88df891516d72cb320450"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]

--- a/ossm-esp/Cargo.toml
+++ b/ossm-esp/Cargo.toml
@@ -11,4 +11,6 @@ edition = "2024"
 esp32s3 = ["esp-hal/esp32s3"]
 
 [dependencies]
+ossm = { path = "../ossm" }
 esp-hal = { version = "~1.0", default-features = false, features = ["unstable"] }
+embedded-io = "0.6.1"

--- a/ossm-esp/src/lib.rs
+++ b/ossm-esp/src/lib.rs
@@ -1,3 +1,4 @@
 #![no_std]
 
 pub mod rs485;
+pub mod uart;

--- a/ossm-esp/src/uart.rs
+++ b/ossm-esp/src/uart.rs
@@ -1,0 +1,31 @@
+use esp_hal::Blocking;
+use esp_hal::uart::Uart;
+
+/// Newtype wrapper around `Uart<Blocking>` that provides non-blocking
+/// reads via `read_buffered()`. The standard `embedded_io::Read` impl
+/// on `Uart<Blocking>` blocks until data arrives, which prevents the
+/// modbus transport from implementing timeouts.
+pub struct NonBlockingUart<'d>(pub Uart<'d, Blocking>);
+
+impl embedded_io::ErrorType for NonBlockingUart<'_> {
+    type Error = esp_hal::uart::IoError;
+}
+
+impl ossm::ReadNonBlocking for NonBlockingUart<'_> {
+    fn read_nb(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+        // read_buffered returns immediately with 0 if the FIFO is empty.
+        // RX errors are treated as "no data" to avoid stalling the
+        // transport on transient UART glitches.
+        Ok(self.0.read_buffered(buf).unwrap_or(0))
+    }
+}
+
+impl embedded_io::Write for NonBlockingUart<'_> {
+    fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+        embedded_io::Write::write(&mut self.0, buf)
+    }
+
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        embedded_io::Write::flush(&mut self.0)
+    }
+}

--- a/ossm/Cargo.toml
+++ b/ossm/Cargo.toml
@@ -15,7 +15,7 @@ embassy-sync = { version = "0.7", default-features = false }
 embassy-time = { version = "0.5", default-features = false }
 embedded-hal = "1.0"
 embedded-hal-async = "1.0"
-embedded-io = "0.7.1"
+embedded-io = "0.6.1"
 heapless = "0.9.2"
 log = "0.4"
 rmodbus = { version = "0.12.2", default-features = false, features = ["heapless"] }

--- a/ossm/src/lib.rs
+++ b/ossm/src/lib.rs
@@ -24,7 +24,7 @@ pub use motion::MotionController;
 pub use motor::{CurrentSensor, Motor, Rs485Motor, SelfHoming, StepDir};
 pub use state::{MotionPhase, MotionState};
 pub use transport::{
-    Modbus, ModbusTransport, Rs485ModbusTransport, StepDirConfig, StepDirError,
+    Modbus, ModbusTransport, ReadNonBlocking, Rs485ModbusTransport, StepDirConfig, StepDirError,
     StepDirMotor, StepOutput, TransportError,
 };
 

--- a/ossm/src/motion.rs
+++ b/ossm/src/motion.rs
@@ -238,6 +238,8 @@ impl<'a, B: Board> MotionController<'a, B> {
             .clamp(self.limits.min_position_mm, self.limits.max_position_mm);
         if let Err(e) = self.board.set_position(mm).await {
             log::error!("Board set_position failed: {:?}", e);
+            self.enter_fault();
+            return Err(e);
         }
         self.output.pass_to_input(&mut self.input);
         self.publish_state();
@@ -382,6 +384,7 @@ impl<'a, B: Board> MotionController<'a, B> {
         let fraction = self.target.as_ref().and_then(|t| t.torque).unwrap_or(1.0);
         if let Err(e) = self.board.set_torque(fraction).await {
             log::error!("Board set_torque failed: {:?}", e);
+            self.enter_fault();
         }
     }
 

--- a/ossm/src/transport/mod.rs
+++ b/ossm/src/transport/mod.rs
@@ -3,5 +3,5 @@ pub mod modbus_rtu;
 pub mod step_dir;
 
 pub use modbus::{Modbus, ModbusTransport};
-pub use modbus_rtu::{Rs485ModbusTransport, TransportError};
+pub use modbus_rtu::{ReadNonBlocking, Rs485ModbusTransport, TransportError};
 pub use step_dir::{StepDirConfig, StepDirError, StepDirMotor, StepOutput};

--- a/ossm/src/transport/modbus_rtu.rs
+++ b/ossm/src/transport/modbus_rtu.rs
@@ -1,11 +1,13 @@
+use embassy_time::Instant;
 use embedded_hal_async::delay::DelayNs;
-use embedded_io::{ErrorType, Read, Write};
+use embedded_io::{ErrorType, Write};
 use heapless::Vec;
 
 use super::ModbusTransport;
 
-const MOTOR_TIMEOUT_RETRIES: usize = 500;
-const RETRY_DELAY_US: u32 = 20;
+const RESPONSE_TIMEOUT_MS: u64 = 100;
+const MAX_RETRIES: usize = 3;
+const POLL_DELAY_US: u32 = 20;
 const INTER_COMMAND_DELAY_US: u32 = 2_000;
 const MIN_FRAME_BYTES: usize = 3;
 const MAX_REGS_PER_READ: usize = 8;
@@ -14,12 +16,23 @@ const MAX_REGS_PER_READ: usize = 8;
 pub enum TransportError<E: core::fmt::Debug> {
     Uart(E),
     Timeout,
+    /// Wire corruption: garbled header, CRC mismatch, etc. Retryable.
+    Corrupt(&'static str),
+    /// Logic/programming error: failed to build request, buffer too small. Fatal.
     Protocol(&'static str),
+}
+
+/// Non-blocking read: returns 0 immediately when no data is available.
+/// Required for timeout support — `embedded_io::Read` on blocking UARTs
+/// hangs forever waiting for data, making timeouts impossible.
+pub trait ReadNonBlocking: ErrorType {
+    fn read_nb(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error>;
 }
 
 /// ModbusTransport over RS485 UART.
 ///
-/// Handles RTU framing, CRC, and response parsing.
+/// Handles RTU framing, CRC, response parsing, and automatic retries
+/// on timeout.
 pub struct Rs485ModbusTransport<UART, DELAY> {
     uart: UART,
     delay: DELAY,
@@ -27,69 +40,83 @@ pub struct Rs485ModbusTransport<UART, DELAY> {
 
 impl<UART, DELAY> Rs485ModbusTransport<UART, DELAY>
 where
-    UART: Read + Write,
+    UART: ReadNonBlocking + Write,
     DELAY: DelayNs,
 {
     pub fn new(uart: UART, delay: DELAY) -> Self {
         Self { uart, delay }
     }
 
+    /// Read exactly `buf.len()` bytes, with a deadline.
     async fn read_exact(
         &mut self,
         buf: &mut [u8],
+        deadline: Instant,
     ) -> Result<(), TransportError<<UART as ErrorType>::Error>> {
         let mut remaining = buf;
-        let mut retries = 0;
         while !remaining.is_empty() {
-            match self.uart.read(remaining) {
-                Ok(0) => {
-                    retries += 1;
-                    if retries >= MOTOR_TIMEOUT_RETRIES {
-                        return Err(TransportError::Timeout);
-                    }
-                    self.delay.delay_us(RETRY_DELAY_US).await;
-                }
-                Ok(n) => {
-                    retries = 0;
-                    remaining = &mut remaining[n..];
-                }
+            if Instant::now() > deadline {
+                return Err(TransportError::Timeout);
+            }
+            match self.uart.read_nb(remaining) {
+                Ok(0) => self.delay.delay_us(POLL_DELAY_US).await,
+                Ok(n) => remaining = &mut remaining[n..],
                 Err(e) => return Err(TransportError::Uart(e)),
             }
         }
         Ok(())
     }
 
+    /// Drain any stale bytes from the RX FIFO.
+    fn drain_rx(&mut self) {
+        let mut junk = [0u8; 32];
+        while let Ok(n) = self.uart.read_nb(&mut junk) {
+            if n == 0 {
+                break;
+            }
+        }
+    }
+
     async fn read_response(
         &mut self,
         buf: &mut [u8],
+        deadline: Instant,
     ) -> Result<usize, TransportError<<UART as ErrorType>::Error>> {
-        self.read_exact(&mut buf[0..MIN_FRAME_BYTES]).await?;
+        self.read_exact(&mut buf[0..MIN_FRAME_BYTES], deadline)
+            .await?;
         let len =
             rmodbus::guess_response_frame_len(&buf[0..MIN_FRAME_BYTES], rmodbus::ModbusProto::Rtu)
-                .map_err(|_| TransportError::Protocol("failed to guess frame length"))?
+                .map_err(|_| TransportError::Corrupt("failed to guess frame length"))?
                 as usize;
+        if len > buf.len() {
+            return Err(TransportError::Corrupt("guessed frame length exceeds buffer"));
+        }
         if len > MIN_FRAME_BYTES {
-            self.read_exact(&mut buf[MIN_FRAME_BYTES..len]).await?;
+            self.read_exact(&mut buf[MIN_FRAME_BYTES..len], deadline)
+                .await?;
         }
         Ok(len)
     }
 
-    async fn send_and_receive(
+    /// Send a request and read the raw response. Single attempt, no retry.
+    async fn exchange(
         &mut self,
         request: &[u8],
         response_buf: &mut [u8],
     ) -> Result<usize, TransportError<<UART as ErrorType>::Error>> {
+        self.drain_rx();
         self.uart.write_all(request).map_err(TransportError::Uart)?;
         self.uart.flush().map_err(TransportError::Uart)?;
-        let len = self.read_response(response_buf).await?;
-        self.delay.delay_us(INTER_COMMAND_DELAY_US).await;
-        Ok(len)
+
+        let deadline =
+            Instant::now() + embassy_time::Duration::from_millis(RESPONSE_TIMEOUT_MS);
+        self.read_response(response_buf, deadline).await
     }
 }
 
 impl<UART, DELAY> ModbusTransport for Rs485ModbusTransport<UART, DELAY>
 where
-    UART: Read + Write,
+    UART: ReadNonBlocking + Write,
     <UART as ErrorType>::Error: core::fmt::Debug,
     DELAY: DelayNs,
 {
@@ -108,11 +135,28 @@ where
             .generate_set_holding(register, value, &mut request)
             .map_err(|_| TransportError::Protocol("failed to generate write request"))?;
         let mut response = [0u8; 32];
-        let len = self.send_and_receive(&request, &mut response).await?;
-        modbus_req
-            .parse_ok(&response[..len])
-            .map_err(|_| TransportError::Protocol("write response parse error"))?;
-        Ok(())
+        for attempt in 0..MAX_RETRIES {
+            match self.exchange(&request, &mut response).await {
+                Ok(len) => match modbus_req.parse_ok(&response[..len]) {
+                    Ok(()) => {
+                        self.delay.delay_us(INTER_COMMAND_DELAY_US).await;
+                        return Ok(());
+                    }
+                    Err(_) => log::warn!(
+                        "Modbus write corrupt response, retry {}/{}",
+                        attempt + 1,
+                        MAX_RETRIES
+                    ),
+                },
+                Err(TransportError::Timeout | TransportError::Corrupt(_)) => log::warn!(
+                    "Modbus write timeout/corrupt, retry {}/{}",
+                    attempt + 1,
+                    MAX_RETRIES
+                ),
+                Err(e) => return Err(e),
+            }
+        }
+        Err(TransportError::Timeout)
     }
 
     async fn read_holding(
@@ -128,12 +172,31 @@ where
             .generate_get_holdings(register, count, &mut request)
             .map_err(|_| TransportError::Protocol("failed to generate read request"))?;
         let mut response = [0u8; 32];
-        let len = self.send_and_receive(&request, &mut response).await?;
-        let mut result: Vec<u16, MAX_REGS_PER_READ> = Vec::new();
-        modbus_req
-            .parse_u16(&response[..len], &mut result)
-            .map_err(|_| TransportError::Protocol("read response parse error"))?;
-        Ok(result)
+        for attempt in 0..MAX_RETRIES {
+            match self.exchange(&request, &mut response).await {
+                Ok(len) => {
+                    let mut result: Vec<u16, MAX_REGS_PER_READ> = Vec::new();
+                    match modbus_req.parse_u16(&response[..len], &mut result) {
+                        Ok(()) => {
+                            self.delay.delay_us(INTER_COMMAND_DELAY_US).await;
+                            return Ok(result);
+                        }
+                        Err(_) => log::warn!(
+                            "Modbus read corrupt response, retry {}/{}",
+                            attempt + 1,
+                            MAX_RETRIES
+                        ),
+                    }
+                }
+                Err(TransportError::Timeout | TransportError::Corrupt(_)) => log::warn!(
+                    "Modbus read timeout/corrupt, retry {}/{}",
+                    attempt + 1,
+                    MAX_RETRIES
+                ),
+                Err(e) => return Err(e),
+            }
+        }
+        Err(TransportError::Timeout)
     }
 
     async fn raw_transaction(
@@ -151,11 +214,25 @@ where
         frame
             .extend_from_slice(&crc)
             .map_err(|_| TransportError::Protocol("request + CRC exceeds frame buffer"))?;
-        self.uart.write_all(&frame).map_err(TransportError::Uart)?;
-        self.uart.flush().map_err(TransportError::Uart)?;
-        let expected_len = response.len();
-        self.read_exact(&mut response[..expected_len]).await?;
-        self.delay.delay_us(INTER_COMMAND_DELAY_US).await;
-        Ok(expected_len)
+        for attempt in 0..MAX_RETRIES {
+            self.drain_rx();
+            self.uart.write_all(&frame).map_err(TransportError::Uart)?;
+            self.uart.flush().map_err(TransportError::Uart)?;
+
+            let deadline =
+                Instant::now() + embassy_time::Duration::from_millis(RESPONSE_TIMEOUT_MS);
+            let expected_len = response.len();
+            match self.read_exact(&mut response[..expected_len], deadline).await {
+                Ok(()) => {
+                    self.delay.delay_us(INTER_COMMAND_DELAY_US).await;
+                    return Ok(expected_len);
+                }
+                Err(TransportError::Timeout | TransportError::Corrupt(_)) => {
+                    log::warn!("Modbus raw timeout/corrupt, retry {}/{}", attempt + 1, MAX_RETRIES);
+                }
+                Err(e) => return Err(e),
+            }
+        }
+        Err(TransportError::Timeout)
     }
 }


### PR DESCRIPTION
## Problem

When frames are corrupt there the motion engine hangs. Frames corrupt for a number of reasons - EMI, power droop - and we should be resilient to that.

## Solution

Attempt to retry sending frames a set number of times, and if that fails 

## Testing

Same testing as #113 with additional forced garbage frames to test retries
