### PR TITLE
feat: Adds reverse direction option to mechanical config

### DIFF
--- a/bindings/web-simulator/src/lib.rs
+++ b/bindings/web-simulator/src/lib.rs
@@ -14,6 +14,7 @@ static PATTERNS: PatternEngine = PatternEngine::new(&OSSM);
 static MECHANICAL: MechanicalConfig = MechanicalConfig {
     pulley_teeth: 20,
     belt_pitch_mm: 2.0,
+    reverse_direction: false,
 };
 
 #[wasm_bindgen]

--- a/boards/rs485/src/lib.rs
+++ b/boards/rs485/src/lib.rs
@@ -30,7 +30,11 @@ impl<M: Rs485Motor + SelfHoming> Board for Rs485Board<M> {
     type Error = BoardError<M::Error>;
 
     async fn enable(&mut self) -> Result<(), Self::Error> {
-        self.motor.enable().await.map_err(BoardError::Motor)
+        self.motor.enable().await.map_err(BoardError::Motor)?;
+        self.motor
+            .set_dir_polarity(self.mechanical.reverse_direction)
+            .await
+            .map_err(BoardError::Motor)
     }
 
     async fn disable(&mut self) -> Result<(), Self::Error> {

--- a/drivers/m57aim/src/rs485.rs
+++ b/drivers/m57aim/src/rs485.rs
@@ -82,6 +82,11 @@ impl<T: ModbusTransport, D> Motor57AIM<Modbus<T>, D> {
             .await
     }
 
+    pub async fn set_dir_polarity(&mut self, reverse: bool) -> Result<(), T::Error> {
+        self.write_register(RwRegister::DirPolarity, reverse as u16)
+            .await
+    }
+
     /// Configure the motor for maximum tracking performance.
     ///
     /// Sets speed, acceleration, and output to maximum so the motor acts
@@ -165,7 +170,11 @@ impl<T: ModbusTransport, D: DelayNs> Motor for Motor57AIM<Modbus<T>, D> {
     }
 }
 
-impl<T: ModbusTransport, D: DelayNs> Rs485Motor for Motor57AIM<Modbus<T>, D> {}
+impl<T: ModbusTransport, D: DelayNs> Rs485Motor for Motor57AIM<Modbus<T>, D> {
+    async fn set_dir_polarity(&mut self, reverse: bool) -> Result<(), Self::Error> {
+        Motor57AIM::set_dir_polarity(self, reverse).await
+    }
+}
 
 impl<T: ModbusTransport, D: DelayNs> SelfHoming for Motor57AIM<Modbus<T>, D> {
     async fn home(&mut self) -> Result<(), Self::Error> {

--- a/firmware/ossm-alt/src/main.rs
+++ b/firmware/ossm-alt/src/main.rs
@@ -105,6 +105,7 @@ async fn main(spawner: Spawner) {
     static MECHANICAL: MechanicalConfig = MechanicalConfig {
         pulley_teeth: 20,
         belt_pitch_mm: 2.0,
+        reverse_direction: false,
     };
     let limits = MotionLimits::default();
 

--- a/firmware/ossm-reference/src/main.rs
+++ b/firmware/ossm-reference/src/main.rs
@@ -120,6 +120,7 @@ async fn main(spawner: Spawner) {
     static MECHANICAL: MechanicalConfig = MechanicalConfig {
         pulley_teeth: 20,
         belt_pitch_mm: 2.0,
+        reverse_direction: false,
     };
     let limits = MotionLimits::default();
 

--- a/firmware/seeed-xiao/src/main.rs
+++ b/firmware/seeed-xiao/src/main.rs
@@ -103,6 +103,7 @@ async fn main(spawner: Spawner) {
     static MECHANICAL: MechanicalConfig = MechanicalConfig {
         pulley_teeth: 20,
         belt_pitch_mm: 2.0,
+        reverse_direction: false,
     };
     let limits = MotionLimits::default();
 

--- a/firmware/waveshare/src/main.rs
+++ b/firmware/waveshare/src/main.rs
@@ -105,6 +105,7 @@ async fn main(spawner: Spawner) {
     static MECHANICAL: MechanicalConfig = MechanicalConfig {
         pulley_teeth: 20,
         belt_pitch_mm: 2.0,
+        reverse_direction: false,
     };
     let limits = MotionLimits::default();
 

--- a/ossm/src/mechanical.rs
+++ b/ossm/src/mechanical.rs
@@ -7,6 +7,9 @@
 pub struct MechanicalConfig {
     pub pulley_teeth: u32,
     pub belt_pitch_mm: f32,
+    /// Flip the sign of commanded positions. Set if the machine moves
+    /// the wrong way for the installed belt orientation.
+    pub reverse_direction: bool,
 }
 
 impl Default for MechanicalConfig {
@@ -14,6 +17,7 @@ impl Default for MechanicalConfig {
         Self {
             pulley_teeth: 20,
             belt_pitch_mm: 2.0,
+            reverse_direction: false,
         }
     }
 }
@@ -29,13 +33,15 @@ impl MechanicalConfig {
         steps_per_rev as f32 / self.mm_per_rev()
     }
 
-    /// Convert mm to steps.
+    /// Convert mm to steps. Flips sign when `reverse_direction` is set.
     pub fn mm_to_steps(&self, mm: f64, steps_per_rev: u32) -> i32 {
+        let mm = if self.reverse_direction { -mm } else { mm };
         (mm * self.steps_per_mm(steps_per_rev) as f64) as i32
     }
 
-    /// Convert steps to mm.
+    /// Convert steps to mm. Flips sign when `reverse_direction` is set.
     pub fn steps_to_mm(&self, steps: i32, steps_per_rev: u32) -> f64 {
-        steps as f64 / self.steps_per_mm(steps_per_rev) as f64
+        let mm = steps as f64 / self.steps_per_mm(steps_per_rev) as f64;
+        if self.reverse_direction { -mm } else { mm }
     }
 }

--- a/ossm/src/motor/rs485.rs
+++ b/ossm/src/motor/rs485.rs
@@ -1,8 +1,17 @@
 use super::Motor;
 
-/// Marker trait for motors wired over RS-485.
-///
-/// No additional methods — this exists so boards can constrain their
-/// motor generic to the correct physical interface at compile time.
+/// Trait for motors wired over RS-485.
 #[allow(async_fn_in_trait)]
-pub trait Rs485Motor: Motor {}
+pub trait Rs485Motor: Motor {
+    /// Set the motor's internal direction polarity.
+    ///
+    /// Affects the motor's built-in homing direction (and the external DIR pin
+    /// interpretation, where applicable). Absolute-position commands use the
+    /// motor's fixed encoder coordinates and are *not* affected — those still
+    /// need to be sign-flipped at the board level.
+    ///
+    /// Default no-op for motors without a configurable polarity register.
+    async fn set_dir_polarity(&mut self, _reverse: bool) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}

--- a/ossm/src/transport/step_dir.rs
+++ b/ossm/src/transport/step_dir.rs
@@ -20,7 +20,6 @@ pub struct StepDirConfig {
     /// Maximum output value for the Motor trait. Step/dir drivers handle
     /// current limiting in hardware, so this is largely informational.
     pub max_output: u16,
-    pub reverse_direction: bool,
 }
 
 impl Default for StepDirConfig {
@@ -28,7 +27,6 @@ impl Default for StepDirConfig {
         Self {
             steps_per_rev: 800,
             max_output: 1000,
-            reverse_direction: false,
         }
     }
 }
@@ -92,10 +90,7 @@ where
             return Ok(());
         }
 
-        let forward = delta > 0;
-        let direction_high = forward ^ self.config.reverse_direction;
-
-        if direction_high {
+        if delta > 0 {
             self.dir.set_high().map_err(StepDirError::Pin)?;
         } else {
             self.dir.set_low().map_err(StepDirError::Pin)?;


### PR DESCRIPTION
## Problem

Physically the motor is large and can get in the way, especially when using the pit clamp.

## Solution

Add a mechanical config option to flip the direction of all movement actions

## Testing

- [x] Test with a ossm-rs
- [x] Test with ossm-reference

Closes #88
