### PR TITLE
refactor: Remove the ability to set timestep from graphs

### DIFF
--- a/apps/web-tools/src/TrajectoryPanel.tsx
+++ b/apps/web-tools/src/TrajectoryPanel.tsx
@@ -44,14 +44,14 @@ function generateTrajectory(
   stroke: number,
   velocity: number,
   sensation: number,
-  timestepMs: number,
   durationSecs: number,
 ): TrajectoryData {
-  const dt = timestepMs / 1000;
+  const rec = getRecorder();
+  const dt = rec.timestep_ms() / 1000;
   const totalSteps = Math.ceil(durationSecs / dt);
 
-  const result = getRecorder().record(
-    pattern, depth, stroke, velocity, sensation, timestepMs, totalSteps,
+  const result = rec.record(
+    pattern, depth, stroke, velocity, sensation, totalSteps,
   );
 
   const stepCount = result.position.length;
@@ -74,15 +74,14 @@ export function useTrajectoryData(inputs: {
   stroke: number;
   velocity: number;
   sensation: number;
-  timestep: number;
   duration: number;
   unitMode: UnitMode;
 }) {
-  const { pattern, depth, stroke, velocity, sensation, timestep, duration, unitMode } = inputs;
+  const { pattern, depth, stroke, velocity, sensation, duration, unitMode } = inputs;
 
   const data = useMemo(
-    () => generateTrajectory(pattern, depth, stroke, velocity, sensation, timestep, duration),
-    [pattern, depth, stroke, velocity, sensation, timestep, duration],
+    () => generateTrajectory(pattern, depth, stroke, velocity, sensation, duration),
+    [pattern, depth, stroke, velocity, sensation, duration],
   );
 
   const rec = getRecorder();
@@ -166,8 +165,6 @@ interface TrajectorySidebarProps extends Omit<ComponentProps<typeof Box>, "child
   onResetDefaults?: () => void;
   duration?: number;
   onDurationValueChange?: (v: number) => void;
-  timestep?: number;
-  onTimestepChange?: (v: number) => void;
   stats?: { duration: number; peakVel: number; peakAccel: number; samples: number } | null;
 }
 
@@ -188,8 +185,6 @@ export function TrajectorySidebar({
   onResetDefaults,
   duration,
   onDurationValueChange,
-  timestep,
-  onTimestepChange,
   stats,
   ...boxProps
 }: TrajectorySidebarProps) {
@@ -245,11 +240,10 @@ export function TrajectorySidebar({
           </>
         )}
 
-        {!compact && duration != null && onDurationValueChange && timestep != null && onTimestepChange && (
+        {!compact && duration != null && onDurationValueChange && (
           <>
             <Separator size="4" />
             <LabeledSlider label="Duration" value={duration} display={`${duration}s`} min={5} max={35} step={1} onChange={onDurationValueChange} />
-            <LabeledSlider label="Timestep" value={timestep} display={`${timestep}ms`} min={1} max={50} step={1} onChange={onTimestepChange} />
           </>
         )}
 

--- a/apps/web-tools/src/hooks/useTrajectoryInputs.ts
+++ b/apps/web-tools/src/hooks/useTrajectoryInputs.ts
@@ -9,7 +9,6 @@ const DEFAULTS = {
   stroke: 0.5,
   velocity: 0.75,
   sensation: 0.0,
-  timestep: 20,
   duration: 20,
   unitMode: "relative" as UnitMode,
 };
@@ -22,7 +21,6 @@ export function useTrajectoryInputs() {
   const [stroke, setStroke] = usePersistedState("ossm:stroke", DEFAULTS.stroke);
   const [velocity, setVelocity] = usePersistedState("ossm:velocity", DEFAULTS.velocity);
   const [sensation, setSensation] = usePersistedState("ossm:sensation", DEFAULTS.sensation);
-  const [timestep, setTimestep] = usePersistedState("ossm:timestep", DEFAULTS.timestep);
   const [duration, setDuration] = usePersistedState("ossm:duration", DEFAULTS.duration);
   const [unitMode, setUnitMode] = usePersistedState<UnitMode>("ossm:unitMode", DEFAULTS.unitMode);
 
@@ -32,10 +30,9 @@ export function useTrajectoryInputs() {
     setStroke(DEFAULTS.stroke);
     setVelocity(DEFAULTS.velocity);
     setSensation(DEFAULTS.sensation);
-    setTimestep(DEFAULTS.timestep);
     setDuration(DEFAULTS.duration);
     setUnitMode(DEFAULTS.unitMode);
-  }, [setPattern, setDepth, setStroke, setVelocity, setSensation, setTimestep, setDuration, setUnitMode]);
+  }, [setPattern, setDepth, setStroke, setVelocity, setSensation, setDuration, setUnitMode]);
 
   return {
     pattern, setPattern,
@@ -43,7 +40,6 @@ export function useTrajectoryInputs() {
     stroke, setStroke,
     velocity, setVelocity,
     sensation, setSensation,
-    timestep, setTimestep,
     duration, setDuration,
     unitMode, setUnitMode,
     resetDefaults,

--- a/apps/web-tools/src/pages/GraphPage.tsx
+++ b/apps/web-tools/src/pages/GraphPage.tsx
@@ -53,8 +53,6 @@ export default function GraphPage() {
       onUnitModeChange={inputs.setUnitMode}
       duration={inputs.duration}
       onDurationValueChange={inputs.setDuration}
-      timestep={inputs.timestep}
-      onTimestepChange={inputs.setTimestep}
       stats={stats}
       onResetDefaults={inputs.resetDefaults}
       compact={isMobile}

--- a/apps/web-tools/src/pages/SimulatorPage.tsx
+++ b/apps/web-tools/src/pages/SimulatorPage.tsx
@@ -199,8 +199,6 @@ export default function SimulatorPage() {
             onUnitModeChange={inputs.setUnitMode}
             duration={inputs.duration}
             onDurationValueChange={inputs.setDuration}
-            timestep={inputs.timestep}
-            onTimestepChange={inputs.setTimestep}
             stats={stats}
             onResetDefaults={inputs.resetDefaults}
           />

--- a/bindings/trajectory-recorder/src/lib.rs
+++ b/bindings/trajectory-recorder/src/lib.rs
@@ -15,6 +15,9 @@ static RECORDER_INPUT: SharedPatternInput = SharedPatternInput::new();
 const LIMITS: MotionLimits = MotionLimits::DEFAULT;
 const RANGE_MM: f64 = LIMITS.max_position_mm - LIMITS.min_position_mm;
 
+// Matches firmware UPDATE_INTERVAL_SECS so the graph reflects what hardware actually does.
+const TIMESTEP_MS: f64 = 10.0;
+
 #[wasm_bindgen]
 pub struct TrajectoryRecorder {}
 
@@ -33,6 +36,10 @@ impl TrajectoryRecorder {
         LIMITS.max_position_mm
     }
 
+    pub fn timestep_ms(&self) -> f64 {
+        TIMESTEP_MS
+    }
+
     /// Record a trajectory returning three `Float32Array`s: position,
     /// velocity, and acceleration (all in the 0-1 domain).
     pub fn record(
@@ -42,10 +49,9 @@ impl TrajectoryRecorder {
         stroke: f64,
         velocity: f64,
         sensation: f64,
-        timestep_ms: f64,
         max_samples: usize,
     ) -> TrajectoryResult {
-        let timestep_secs = timestep_ms / 1000.0;
+        let timestep_secs = TIMESTEP_MS / 1000.0;
 
         let mut planner = RuckigPlanner::new(
             LIMITS.max_velocity_mm_s / RANGE_MM,
@@ -74,7 +80,7 @@ impl TrajectoryRecorder {
             &mut planner,
             input,
             rest_position,
-            timestep_ms,
+            TIMESTEP_MS,
             max_samples,
         );
 


### PR DESCRIPTION
## Problem

Allowing users to edit timestep doesn't do anything meaningful and is confusing as the graph jumps around

## Solution

Lock the timestep to the same interval as the wasm firmware

## Testing

Tested the demo links