### PR TITLE
fix: Bump stack sizes

### DIFF
--- a/firmware/ossm-alt/src/main.rs
+++ b/firmware/ossm-alt/src/main.rs
@@ -56,7 +56,7 @@ static OSSM: Ossm = Ossm::new();
 static PATTERNS: PatternEngine = PatternEngine::new(&OSSM);
 
 static EXECUTOR_CORE_1: StaticCell<InterruptExecutor<2>> = StaticCell::new();
-static APP_CORE_STACK: StaticCell<Stack<16384>> = StaticCell::new();
+static APP_CORE_STACK: StaticCell<Stack<32768>> = StaticCell::new();
 static MOTION_READY: Signal<CriticalSectionRawMutex, bool> = Signal::new();
 
 #[embassy_executor::task]

--- a/firmware/ossm-reference/src/main.rs
+++ b/firmware/ossm-reference/src/main.rs
@@ -65,7 +65,7 @@ static EXECUTOR_CORE_1: StaticCell<InterruptExecutor<2>> = StaticCell::new();
 // trajectory calculator (heavy float math). 64KB heap is needed for the BLE
 // radio stack's internal allocations. ESP-NOW was dropped to fit within
 // the ESP32's memory constraints.
-static APP_CORE_STACK: StaticCell<Stack<16384>> = StaticCell::new();
+static APP_CORE_STACK: StaticCell<Stack<32768>> = StaticCell::new();
 static MOTION_READY: Signal<CriticalSectionRawMutex, bool> = Signal::new();
 
 #[embassy_executor::task]

--- a/firmware/seeed-xiao/src/main.rs
+++ b/firmware/seeed-xiao/src/main.rs
@@ -57,7 +57,7 @@ static OSSM: Ossm = Ossm::new();
 static PATTERNS: PatternEngine = PatternEngine::new(&OSSM);
 
 static EXECUTOR_CORE_1: StaticCell<InterruptExecutor<2>> = StaticCell::new();
-static APP_CORE_STACK: StaticCell<Stack<16384>> = StaticCell::new();
+static APP_CORE_STACK: StaticCell<Stack<32768>> = StaticCell::new();
 static MOTION_READY: Signal<CriticalSectionRawMutex, bool> = Signal::new();
 
 #[embassy_executor::task]

--- a/firmware/waveshare/src/main.rs
+++ b/firmware/waveshare/src/main.rs
@@ -57,7 +57,7 @@ static OSSM: Ossm = Ossm::new();
 static PATTERNS: PatternEngine = PatternEngine::new(&OSSM);
 
 static EXECUTOR_CORE_1: StaticCell<InterruptExecutor<2>> = StaticCell::new();
-static APP_CORE_STACK: StaticCell<Stack<16384>> = StaticCell::new();
+static APP_CORE_STACK: StaticCell<Stack<32768>> = StaticCell::new();
 static MOTION_READY: Signal<CriticalSectionRawMutex, bool> = Signal::new();
 
 #[embassy_executor::task]


### PR DESCRIPTION
## Problem

When thrashing BLE changes, the second core can panic with memory being written past the stack guard on core 1 (motion controller core)

## Solution

Increase stack size of motion controller core

## Testing

Each supported mcu family should be tested
- [ ] esp32s3
- [ ] esp32 - this one needs the most attention due to it's limited memory
