### PR TITLE
Ossm commands

### DIFF
--- a/bindings/web-simulator/src/lib.rs
+++ b/bindings/web-simulator/src/lib.rs
@@ -3,7 +3,10 @@ use alloc::string::String;
 
 use embassy_time::{Delay, Duration, Ticker};
 use ossm::{MechanicalConfig, MotionLimits, Ossm};
-use pattern_engine::{AnyPattern, PatternEngine};
+use pattern_engine::{
+    AnyPattern, PatternEngine,
+    commands::{self, InputCommand, PlaybackCommand},
+};
 use sim_board::SimBoard;
 use sim_motor::SimMotor;
 use wasm_bindgen::prelude::*;
@@ -64,7 +67,7 @@ impl Simulator {
     }
 
     pub fn get_engine_state(&self) -> u8 {
-        PATTERNS.state().as_u8()
+        commands::current_state(&PATTERNS).as_u8()
     }
 
     pub fn get_position(&self) -> f32 {
@@ -72,68 +75,51 @@ impl Simulator {
     }
 
     pub fn set_depth(&self, depth: f64) {
-        PATTERNS.input().sender().send_modify(|opt| {
-            if let Some(input) = opt {
-                input.depth = depth;
-            }
-        });
+        commands::dispatch_input(&PATTERNS, InputCommand::SetDepth(depth));
     }
 
     pub fn set_stroke(&self, stroke: f64) {
-        PATTERNS.input().sender().send_modify(|opt| {
-            if let Some(input) = opt {
-                input.stroke = stroke;
-            }
-        });
+        commands::dispatch_input(&PATTERNS, InputCommand::SetStroke(stroke));
     }
 
     pub fn set_velocity(&self, velocity: f64) {
-        PATTERNS.input().sender().send_modify(|opt| {
-            if let Some(input) = opt {
-                input.velocity = velocity;
-            }
-        });
+        commands::dispatch_input(&PATTERNS, InputCommand::SetSpeed(velocity));
     }
 
     pub fn set_sensation(&self, sensation: f64) {
-        PATTERNS.input().sender().send_modify(|opt| {
-            if let Some(input) = opt {
-                input.sensation = sensation;
-            }
-        });
+        commands::dispatch_input(&PATTERNS, InputCommand::SetSensation(sensation));
     }
 
     pub fn play(&self, index: usize) {
-        PATTERNS.play(index);
+        commands::dispatch_playback(&PATTERNS, PlaybackCommand::Play(index));
     }
 
     pub fn pause(&self) {
-        PATTERNS.pause();
+        commands::dispatch_playback(&PATTERNS, PlaybackCommand::Pause);
     }
 
     pub fn resume(&self) {
-        PATTERNS.resume();
+        commands::dispatch_playback(&PATTERNS, PlaybackCommand::Resume);
     }
 
     pub fn stop(&self) {
-        PATTERNS.stop();
+        commands::dispatch_playback(&PATTERNS, PlaybackCommand::Stop);
     }
 
     pub fn pattern_count(&self) -> usize {
-        AnyPattern::BUILTIN_PATTERNS.len()
+        commands::pattern_list().len()
     }
 
     pub fn pattern_name(&self, index: usize) -> String {
-        AnyPattern::BUILTIN_PATTERNS
+        commands::pattern_list()
             .get(index)
             .map(|p| String::from(p.name))
             .unwrap_or_default()
     }
 
     pub fn pattern_description(&self, index: usize) -> String {
-        AnyPattern::BUILTIN_PATTERNS
-            .get(index)
-            .map(|p| String::from(p.description))
+        commands::pattern_description(index)
+            .map(String::from)
             .unwrap_or_default()
     }
 }

--- a/crates/ble-remote/src/lib.rs
+++ b/crates/ble-remote/src/lib.rs
@@ -17,7 +17,10 @@ use embassy_time::{Duration, Ticker, Timer};
 use esp_radio::ble::controller::BleConnector;
 use heapless::String;
 use log::{error, info, warn};
-use pattern_engine::{AnyPattern, EngineState, PatternEngine};
+use pattern_engine::{
+    EngineState, PatternEngine, PatternInput,
+    commands::{self, InputCommand, PlaybackCommand},
+};
 use static_cell::StaticCell;
 use trouble_host::prelude::*;
 
@@ -63,7 +66,7 @@ struct OssmService {
 fn get_all_patterns_json() -> String<MAX_PATTERN_LENGTH> {
     let mut output: String<MAX_PATTERN_LENGTH> = String::new();
     output.write_char('[').ok();
-    for (i, meta) in AnyPattern::BUILTIN_PATTERNS.iter().enumerate() {
+    for (i, meta) in commands::pattern_list().iter().enumerate() {
         let rollback = output.len();
         let sep = if i > 0 { "," } else { "" };
         if write!(output, r#"{sep}{{"name":"{}","idx":{i}}}"#, meta.name).is_err()
@@ -81,10 +84,7 @@ fn get_all_patterns_json() -> String<MAX_PATTERN_LENGTH> {
 fn get_pattern_description(index: usize) -> String<MAX_PATTERN_LENGTH> {
     let mut output = String::new();
 
-    let description = AnyPattern::BUILTIN_PATTERNS
-        .get(index)
-        .map(|m| m.description)
-        .unwrap_or("Invalid pattern index");
+    let description = commands::pattern_description(index).unwrap_or("Invalid pattern index");
 
     if output.push_str(description).is_err() {
         output
@@ -197,7 +197,7 @@ pub async fn ble_events_task(
                     },
                 }
 
-                engine.stop();
+                commands::dispatch_playback(engine, PlaybackCommand::Stop);
                 info!("BLE session ended, stopping engine");
             }
             Err(err) => {
@@ -232,9 +232,8 @@ async fn gatt_events_task<P: PacketPool>(
                 match &event {
                     GattEvent::Read(event) => {
                         if event.handle() == server.ossm_service.current_state.handle {
-                            use pattern_engine::PatternInput;
-                            let engine_state = engine.state();
-                            let input = engine.input().try_get().unwrap_or(PatternInput::DEFAULT);
+                            let engine_state = commands::current_state(engine);
+                            let input = commands::current_input(engine);
                             let state_json = state_to_json(engine_state, &input);
                             server.set(&server.ossm_service.current_state, &state_json)?;
                         }
@@ -334,20 +333,17 @@ async fn state_notifications<P: PacketPool>(
     connection: &GattConnection<'_, '_, P>,
     engine: &'static PatternEngine,
 ) -> Result<(), Error> {
-    use pattern_engine::PatternInput;
-
-    let mut sub = engine
-        .state_subscriber()
-        .expect("No state subscriber slots available");
+    let mut sub =
+        commands::subscribe_state(engine).expect("No state subscriber slots available");
     let mut heartbeat = Ticker::every(Duration::from_secs(1));
 
     loop {
         let engine_state = match select(sub.next_message_pure(), heartbeat.next()).await {
             Either::First(state) => state,
-            Either::Second(_) => engine.state(),
+            Either::Second(_) => commands::current_state(engine),
         };
 
-        let input = engine.input().try_get().unwrap_or(PatternInput::DEFAULT);
+        let input = commands::current_input(engine);
         let state_json = state_to_json(engine_state, &input);
         server
             .ossm_service
@@ -357,12 +353,9 @@ async fn state_notifications<P: PacketPool>(
     }
 }
 
-fn state_to_json(
-    state: EngineState,
-    input: &pattern_engine::PatternInput,
-) -> String<MAX_STATE_LENGTH> {
+fn state_to_json(state: EngineState, input: &PatternInput) -> String<MAX_STATE_LENGTH> {
     let pattern_name = match state {
-        EngineState::Playing(idx) | EngineState::Paused(idx) => AnyPattern::BUILTIN_PATTERNS
+        EngineState::Playing(idx) | EngineState::Paused(idx) => commands::pattern_list()
             .get(idx)
             .map(|m| m.name)
             .unwrap_or(""),
@@ -409,42 +402,29 @@ fn process_command(
                 "set" => {
                     if let Some(value) = split_command.next() {
                         if let Ok(value) = value.parse::<u32>() {
-                            let clamped_value = (value as f64 / 100.0).clamp(0.0, 1.0);
+                            let normalized = value as f64 / 100.0;
                             match action {
-                                "speed" => {
-                                    engine.input().sender().send_modify(|opt| {
-                                        if let Some(input) = opt {
-                                            input.velocity = clamped_value;
-                                        }
-                                    });
-                                }
-                                "stroke" => {
-                                    engine.input().sender().send_modify(|opt| {
-                                        if let Some(input) = opt {
-                                            input.stroke = clamped_value;
-                                        }
-                                    });
-                                }
-                                "depth" => {
-                                    engine.input().sender().send_modify(|opt| {
-                                        if let Some(input) = opt {
-                                            input.depth = clamped_value;
-                                        }
-                                    });
-                                }
-                                "sensation" => {
-                                    // BLE sends 0–100 (matching reference protocol).
-                                    // Map to internal -1.0..1.0 range.
-                                    let sensation = (clamped_value * 2.0 - 1.0).clamp(-1.0, 1.0);
-                                    engine.input().sender().send_modify(|opt| {
-                                        if let Some(input) = opt {
-                                            input.sensation = sensation;
-                                        }
-                                    });
-                                }
-                                "pattern" => {
-                                    engine.play(value as usize);
-                                }
+                                "speed" => commands::dispatch_input(
+                                    engine,
+                                    InputCommand::SetSpeed(normalized),
+                                ),
+                                "stroke" => commands::dispatch_input(
+                                    engine,
+                                    InputCommand::SetStroke(normalized),
+                                ),
+                                "depth" => commands::dispatch_input(
+                                    engine,
+                                    InputCommand::SetDepth(normalized),
+                                ),
+                                // BLE sends 0–100; internal range is -1.0..1.0.
+                                "sensation" => commands::dispatch_input(
+                                    engine,
+                                    InputCommand::SetSensation(normalized * 2.0 - 1.0),
+                                ),
+                                "pattern" => commands::dispatch_playback(
+                                    engine,
+                                    PlaybackCommand::Play(value as usize),
+                                ),
                                 _ => {
                                     error!("Invalid set command {}", action);
                                     fail = true;
@@ -460,9 +440,10 @@ fn process_command(
                     }
                 }
                 "go" => match action {
-                    "simplePenetration" => engine.play(0),
-                    "strokeEngine" => engine.play(0),
-                    "menu" => engine.stop(),
+                    "simplePenetration" | "strokeEngine" => {
+                        commands::dispatch_playback(engine, PlaybackCommand::Play(0))
+                    }
+                    "menu" => commands::dispatch_playback(engine, PlaybackCommand::Stop),
                     _ => {
                         error!("Unknown go action: {}", action);
                         fail = true;

--- a/crates/ossm-m5-remote/src/lib.rs
+++ b/crates/ossm-m5-remote/src/lib.rs
@@ -10,7 +10,10 @@ use esp_radio::esp_now::{
     BROADCAST_ADDRESS, EspNowManager, EspNowReceiver, EspNowSender, PeerInfo,
 };
 use log::{error, info};
-use pattern_engine::PatternEngine;
+use pattern_engine::{
+    PatternEngine,
+    commands::{self, InputCommand, PlaybackCommand},
+};
 use portable_atomic::{AtomicU32, AtomicU64};
 use zerocopy::{Immutable, IntoBytes, KnownLayout, TryFromBytes};
 
@@ -238,7 +241,7 @@ async fn receiver_task(
                 }
                 let current = CURRENT_PATTERN_IDX.load(Ordering::Acquire) as usize;
                 info!("Playing pattern {}", current);
-                engine.play(current);
+                commands::dispatch_playback(engine, PlaybackCommand::Play(current));
             }
             M5Command::Off => {
                 let ack = M5Packet {
@@ -252,41 +255,25 @@ async fn receiver_task(
                         error!("Could not send OFF ack: {}", err);
                     }
                 }
-                engine.pause();
+                commands::dispatch_playback(engine, PlaybackCommand::Pause);
                 info!("Paused");
             }
             M5Command::Speed => {
                 let velocity = (packet.value as f64) / config.max_velocity_mm_s;
-                engine.input().sender().send_modify(|opt| {
-                    if let Some(input) = opt {
-                        input.velocity = velocity.clamp(0.0, 1.0);
-                    }
-                });
+                commands::dispatch_input(engine, InputCommand::SetSpeed(velocity));
             }
             M5Command::Depth => {
                 let depth = (packet.value as f64) / config.max_travel_mm;
-                engine.input().sender().send_modify(|opt| {
-                    if let Some(input) = opt {
-                        input.depth = depth.clamp(0.0, 1.0);
-                    }
-                });
+                commands::dispatch_input(engine, InputCommand::SetDepth(depth));
             }
             M5Command::Stroke => {
                 let stroke = (packet.value as f64) / config.max_travel_mm;
-                engine.input().sender().send_modify(|opt| {
-                    if let Some(input) = opt {
-                        input.stroke = stroke.clamp(0.0, 1.0);
-                    }
-                });
+                commands::dispatch_input(engine, InputCommand::SetStroke(stroke));
             }
             M5Command::Sensation => {
                 // Remote sends -100..100; pattern engine expects -1.0..1.0
-                let sensation = ((packet.value as f64) / 100.0).clamp(-1.0, 1.0);
-                engine.input().sender().send_modify(|opt| {
-                    if let Some(input) = opt {
-                        input.sensation = sensation;
-                    }
-                });
+                let sensation = (packet.value as f64) / 100.0;
+                commands::dispatch_input(engine, InputCommand::SetSensation(sensation));
             }
             M5Command::Pattern => {
                 let remote_idx = packet.value as u32;
@@ -294,7 +281,10 @@ async fn receiver_task(
                     let engine_idx = pattern.to_engine_index();
                     CURRENT_PATTERN_IDX.store(engine_idx, Ordering::Release);
                     info!("Switching to pattern {}", engine_idx);
-                    engine.play(engine_idx as usize);
+                    commands::dispatch_playback(
+                        engine,
+                        PlaybackCommand::Play(engine_idx as usize),
+                    );
                 }
             }
             M5Command::Heartbeat => {
@@ -367,7 +357,7 @@ async fn heartbeat_check_task(engine: &'static PatternEngine) {
 
         if was_connected && !is_connected {
             info!("Remote disconnected, heartbeat lost");
-            engine.pause();
+            commands::dispatch_playback(engine, PlaybackCommand::Pause);
         } else if !was_connected && is_connected {
             info!("Remote connected");
         }

--- a/crates/pattern-engine/src/commands.rs
+++ b/crates/pattern-engine/src/commands.rs
@@ -1,0 +1,75 @@
+//! Public API for remote adapters — the full surface a new remote needs.
+
+use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
+use embassy_sync::pubsub::{self, Subscriber};
+
+use crate::{AnyPattern, EngineState, PatternEngine, PatternInput, PatternMeta};
+
+#[derive(Debug, Clone, Copy)]
+pub enum PlaybackCommand {
+    Play(usize),
+    Pause,
+    Resume,
+    Stop,
+    Home,
+}
+
+/// Input values are clamped to their valid range on dispatch.
+#[derive(Debug, Clone, Copy)]
+pub enum InputCommand {
+    /// 0.0–1.0 (fraction of max velocity).
+    SetSpeed(f64),
+    /// 0.0–1.0 (fraction of depth).
+    SetStroke(f64),
+    /// 0.0–1.0 (fraction of machine range).
+    SetDepth(f64),
+    /// -1.0–1.0 (pattern-specific).
+    SetSensation(f64),
+}
+
+pub fn dispatch_playback(engine: &PatternEngine, cmd: PlaybackCommand) {
+    match cmd {
+        PlaybackCommand::Play(idx) => engine.play(idx),
+        PlaybackCommand::Pause => engine.pause(),
+        PlaybackCommand::Resume => engine.resume(),
+        PlaybackCommand::Stop => engine.stop(),
+        PlaybackCommand::Home => engine.home(),
+    }
+}
+
+pub fn dispatch_input(engine: &PatternEngine, cmd: InputCommand) {
+    engine.input().sender().send_modify(|opt| {
+        if let Some(input) = opt {
+            match cmd {
+                InputCommand::SetSpeed(v) => input.velocity = v.clamp(0.0, 1.0),
+                InputCommand::SetStroke(v) => input.stroke = v.clamp(0.0, 1.0),
+                InputCommand::SetDepth(v) => input.depth = v.clamp(0.0, 1.0),
+                InputCommand::SetSensation(v) => input.sensation = v.clamp(-1.0, 1.0),
+            }
+        }
+    });
+}
+
+pub fn current_state(engine: &PatternEngine) -> EngineState {
+    engine.state()
+}
+
+pub fn current_input(engine: &PatternEngine) -> PatternInput {
+    engine.input().try_get().unwrap_or(PatternInput::DEFAULT)
+}
+
+pub fn pattern_list() -> &'static [PatternMeta] {
+    &AnyPattern::BUILTIN_PATTERNS
+}
+
+pub fn pattern_description(idx: usize) -> Option<&'static str> {
+    AnyPattern::BUILTIN_PATTERNS
+        .get(idx)
+        .map(|m| m.description)
+}
+
+pub type StateSubscriber<'a> = Subscriber<'a, CriticalSectionRawMutex, EngineState, 1, 8, 0>;
+
+pub fn subscribe_state(engine: &PatternEngine) -> Result<StateSubscriber<'_>, pubsub::Error> {
+    engine.state_subscriber()
+}

--- a/crates/pattern-engine/src/engine.rs
+++ b/crates/pattern-engine/src/engine.rs
@@ -128,23 +128,11 @@ impl PatternEngine {
         }
     }
 
-    pub fn input(&self) -> &SharedPatternInput {
+    pub(crate) fn input(&self) -> &SharedPatternInput {
         &self.input
     }
 
-    /// Create an async subscriber that receives [`EngineState`] on every
-    /// state transition.
-    ///
-    /// Returns `Err` if all subscriber slots are in use.
-    ///
-    /// ```ignore
-    /// let mut sub = engine.state_subscriber()?;
-    /// loop {
-    ///     let state = sub.next_message_pure().await;
-    ///     // react to state change …
-    /// }
-    /// ```
-    pub fn state_subscriber(
+    pub(crate) fn state_subscriber(
         &self,
     ) -> Result<pubsub::Subscriber<'_, CriticalSectionRawMutex, EngineState, 1, 8, 0>, pubsub::Error>
     {
@@ -162,32 +150,32 @@ impl PatternEngine {
         }
     }
 
-    pub fn ossm(&self) -> &Ossm {
+    pub(crate) fn ossm(&self) -> &Ossm {
         self.ossm
     }
 
-    pub fn play(&self, index: usize) {
+    pub(crate) fn play(&self, index: usize) {
         let _ = self.channels.commands.try_send(EngineCommand::Play(index));
     }
 
-    pub fn pause(&self) {
+    pub(crate) fn pause(&self) {
         let _ = self.channels.commands.try_send(EngineCommand::Pause);
     }
 
-    pub fn resume(&self) {
+    pub(crate) fn resume(&self) {
         let _ = self.channels.commands.try_send(EngineCommand::Resume);
     }
 
-    pub fn stop(&self) {
+    pub(crate) fn stop(&self) {
         let _ = self.channels.commands.try_send(EngineCommand::Stop);
         self.input.sender().send(PatternInput::DEFAULT);
     }
 
-    pub fn home(&self) {
+    pub(crate) fn home(&self) {
         let _ = self.channels.commands.try_send(EngineCommand::Home);
     }
 
-    pub fn state(&self) -> EngineState {
+    pub(crate) fn state(&self) -> EngineState {
         self.channels.state()
     }
 

--- a/crates/pattern-engine/src/lib.rs
+++ b/crates/pattern-engine/src/lib.rs
@@ -1,5 +1,6 @@
 #![no_std]
 
+pub mod commands;
 mod engine;
 mod input;
 mod pattern;

--- a/ossm/src/command.rs
+++ b/ossm/src/command.rs
@@ -39,6 +39,16 @@ pub struct MotionCommand {
     pub torque: Option<f64>,
 }
 
+impl MotionCommand {
+    pub fn clamped(self) -> Self {
+        Self {
+            position: self.position.clamp(0.0, 1.0),
+            speed: self.speed.clamp(0.0, 1.0),
+            torque: self.torque.map(|t| t.clamp(0.0, 1.0)),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 pub enum StateCommand {
     Enable,

--- a/ossm/src/lib.rs
+++ b/ossm/src/lib.rs
@@ -87,13 +87,13 @@ impl Ossm {
     pub fn begin_motion(&self, cmd: MotionCommand) {
         self.channels.move_resp.reset();
         let _ = self.channels.move_cmd.try_receive();
-        let _ = self.channels.move_cmd.try_send(cmd);
+        let _ = self.channels.move_cmd.try_send(cmd.clamped());
     }
 
     /// Update the target of an in-flight motion without resetting the completion signal.
     pub fn update_motion(&self, cmd: MotionCommand) {
         let _ = self.channels.move_cmd.try_receive();
-        let _ = self.channels.move_cmd.try_send(cmd);
+        let _ = self.channels.move_cmd.try_send(cmd.clamped());
     }
 
     /// Wait for the current in-flight motion to complete.


### PR DESCRIPTION
This PR depends on #127 

## Problem

There are a number of different ways to interact with the pattern engine and there is inconsistent clamping being applied to user inputs.

## Solution

Refactor the pattern commands and shift them to a commands.rs file for easy reference. Apply consistent clamping both at the pattern input and motion planning level. The BLE remote and esp-now remotes have been updated to reference these new pattern commands.

## Testing

- [ ] esp32s3
- [ ] esp32
- [ ] sim