### PR TITLE
fix(m5-remote): Fixed wifi drop for m5 remote

### DIFF
--- a/firmware/esp32s3/src/radio.rs
+++ b/firmware/esp32s3/src/radio.rs
@@ -23,8 +23,11 @@ pub fn start(
         esp_radio::init().expect("Failed to initialize radio controller")
     );
 
-    let (mut wifi_controller, interfaces) =
+    let (wifi_controller, interfaces) =
         esp_radio::wifi::new(radio, wifi, Default::default()).unwrap();
+
+    let wifi_controller = mk_static!(esp_radio::wifi::WifiController<'static>, wifi_controller);
+
     wifi_controller
         .set_mode(esp_radio::wifi::WifiMode::Sta)
         .unwrap();
@@ -47,7 +50,7 @@ pub fn start(
 
     ossm_m5_remote::start(spawner, manager, sender, receiver, patterns, remote_config);
 
-    let connector = BleConnector::new(radio, bt, Default::default())
-        .expect("Could not create BleConnector");
+    let connector =
+        BleConnector::new(radio, bt, Default::default()).expect("Could not create BleConnector");
     ble_remote::start(spawner, connector, patterns);
 }


### PR DESCRIPTION
## Problem

@lisaQrunch on discord reported not being able to connect an m5 to 0.8.0

## Solution

During the refactor to deduplicate firmware code, the wifi controller was moved from the main function where it would life forever to a composition function where it was dropped. The controller is deinitialized during drop.

## Testing

Tested with ossm-alt and m5. I was able to replicate the behavior and I'm satisfied it's corrected.

## Note

I also update the reference submodule as I was investigating if the new m5 firmware may have changed something.