### PR TITLE
feat(ossm-flash): Adds a flashing tool for future telemetry multiplexing

### DIFF
--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -63,7 +63,7 @@ jobs:
       - uses: extractions/setup-just@v2
 
       - name: Build ${{ matrix.firmware }}
-        run: just build-${{ matrix.firmware }}
+        run: just build ${{ matrix.firmware }}
         env:
           OSSM_RELEASE_ID: ${{ inputs.release-id }}
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c583acf993cf4245c4acb0a2cc2ab1f9cc097de73411bb6d3647ff6af2b1013d"
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -51,24 +101,6 @@ name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
-
-[[package]]
-name = "ble-remote"
-version = "0.1.0"
-dependencies = [
- "bt-hci",
- "embassy-executor",
- "embassy-futures",
- "embassy-sync 0.7.2",
- "embassy-time",
- "esp-radio",
- "heapless 0.9.2",
- "log",
- "pattern-engine",
- "portable-atomic",
- "static_cell",
- "trouble-host",
-]
 
 [[package]]
 name = "block-buffer"
@@ -125,6 +157,52 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "convert_case"
@@ -956,6 +1034,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1071,6 +1155,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
 name = "ossm"
 version = "0.1.0"
 dependencies = [
@@ -1084,6 +1174,14 @@ dependencies = [
  "log",
  "rmodbus",
  "rsruckig",
+]
+
+[[package]]
+name = "ossm-flash"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
 ]
 
 [[package]]
@@ -1175,6 +1273,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "radr-remote"
+version = "0.1.0"
+dependencies = [
+ "bt-hci",
+ "embassy-executor",
+ "embassy-futures",
+ "embassy-sync 0.7.2",
+ "embassy-time",
+ "esp-radio",
+ "heapless 0.9.2",
+ "log",
+ "pattern-engine",
+ "portable-atomic",
+ "static_cell",
+ "trouble-host",
 ]
 
 [[package]]
@@ -1574,6 +1690,12 @@ dependencies = [
  "heapless 0.8.0",
  "portable-atomic",
 ]
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/README.md
+++ b/README.md
@@ -175,18 +175,12 @@ Features are optional higher-level capabilities built on top of the core motion 
    cargo install espflash
    ```
 
-5. You should now be able to build and flash:
+5. You should now be able to build and flash. The variant is the first argument; supported variants are `ossm-alt` (ESP32-S3, RS485), `waveshare` (ESP32-S3-RS485-CAN), `seeed-xiao` (XIAO ESP32-S3), and `ossm-reference` (ESP32, step/dir).
 
    ```sh
-   just build-ossm-alt        # OSSM Alt Edition (ESP32-S3, RS485)
-   just build-ossm-reference  # OSSM Reference Board (ESP32, step/dir)
-   just build-waveshare       # Waveshare ESP32-S3-RS485-CAN
-   just build-seeed-xiao      # Seeed Studio XIAO ESP32-S3
-
-   just flash-ossm-alt        # Build + flash OSSM Alt Edition
-   just flash-ossm-reference  # Build + flash OSSM Reference Board
-   just flash-waveshare       # Build + flash Waveshare
-   just flash-seeed-xiao      # Build + flash Seeed XIAO
+   just build ossm-alt        # build only
+   just flash ossm-alt        # build + flash + monitor
+   just flash seeed-xiao sim  # flash a build with the simulated motor
    ```
 
 #### Configuring rust-analyzer

--- a/crates/ossm-flash/Cargo.toml
+++ b/crates/ossm-flash/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "ossm-flash"
+version = "0.1.0"
+edition = "2024"
+description = "Build, flash, and monitor OSSM firmware variants"
+
+[[bin]]
+name = "ossm-flash"
+path = "src/main.rs"
+
+[dependencies]
+clap = { version = "4.5", features = ["derive"] }
+anyhow = "1"

--- a/crates/ossm-flash/src/main.rs
+++ b/crates/ossm-flash/src/main.rs
@@ -1,0 +1,197 @@
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+use anyhow::{bail, Context, Result};
+use clap::{Parser, ValueEnum};
+
+#[derive(Parser, Debug)]
+#[command(name = "ossm-flash", about = "Build, flash, and monitor OSSM firmware")]
+struct Cli {
+    /// Firmware variant to build and flash.
+    variant: Variant,
+
+    /// Motor backend to compile in. Defaults to the variant's hardware motor.
+    /// Use `sim` to flash a build with the simulated motor instead.
+    #[arg(long, value_enum)]
+    motor: Option<Motor>,
+
+    /// Skip the build step and flash whatever ELF is already on disk.
+    #[arg(long, conflicts_with = "build_only")]
+    no_build: bool,
+
+    /// Build only; do not flash or monitor. Used by CI.
+    #[arg(long)]
+    build_only: bool,
+
+    /// Override the serial port (otherwise espflash auto-detects).
+    #[arg(long)]
+    port: Option<String>,
+}
+
+#[derive(Copy, Clone, Debug, ValueEnum)]
+#[value(rename_all = "kebab-case")]
+enum Variant {
+    OssmAlt,
+    Waveshare,
+    SeeedXiao,
+    OssmReference,
+}
+
+#[derive(Copy, Clone, Debug, ValueEnum, PartialEq, Eq)]
+#[value(rename_all = "kebab-case")]
+enum Motor {
+    Rs485,
+    Stepdir,
+    Sim,
+}
+
+struct VariantSpec {
+    workspace: &'static str,
+    bin: &'static str,
+    target: &'static str,
+    default_motor: Motor,
+}
+
+impl Variant {
+    fn spec(self) -> VariantSpec {
+        match self {
+            Variant::OssmAlt => VariantSpec {
+                workspace: "firmware/esp32s3",
+                bin: "ossm-alt",
+                target: "xtensa-esp32s3-none-elf",
+                default_motor: Motor::Rs485,
+            },
+            Variant::Waveshare => VariantSpec {
+                workspace: "firmware/esp32s3",
+                bin: "waveshare",
+                target: "xtensa-esp32s3-none-elf",
+                default_motor: Motor::Rs485,
+            },
+            Variant::SeeedXiao => VariantSpec {
+                workspace: "firmware/esp32s3",
+                bin: "seeed-xiao",
+                target: "xtensa-esp32s3-none-elf",
+                default_motor: Motor::Rs485,
+            },
+            Variant::OssmReference => VariantSpec {
+                workspace: "firmware/esp32",
+                bin: "ossm-reference",
+                target: "xtensa-esp32-none-elf",
+                default_motor: Motor::Stepdir,
+            },
+        }
+    }
+}
+
+impl Motor {
+    fn feature(self) -> &'static str {
+        match self {
+            Motor::Rs485 => "motor-rs485",
+            Motor::Stepdir => "motor-stepdir",
+            Motor::Sim => "motor-sim",
+        }
+    }
+}
+
+fn workspace_root() -> Result<PathBuf> {
+    // ossm-flash lives at <root>/crates/ossm-flash; CARGO_MANIFEST_DIR points there.
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    manifest
+        .ancestors()
+        .nth(2)
+        .map(PathBuf::from)
+        .context("could not resolve workspace root from CARGO_MANIFEST_DIR")
+}
+
+fn run_build(spec: &VariantSpec, motor: Motor) -> Result<PathBuf> {
+    let root = workspace_root()?;
+    let workspace_dir = root.join(spec.workspace);
+
+    eprintln!(
+        "ossm-flash: building {} ({}) in {}",
+        spec.bin,
+        motor.feature(),
+        workspace_dir.display()
+    );
+
+    let status = Command::new("cargo")
+        .current_dir(&workspace_dir)
+        .args([
+            "+esp",
+            "build",
+            "--release",
+            "--bin",
+            spec.bin,
+            "--features",
+            motor.feature(),
+        ])
+        .status()
+        .context("failed to invoke `cargo +esp build` (is the esp toolchain installed?)")?;
+
+    if !status.success() {
+        bail!("cargo build failed for {}", spec.bin);
+    }
+
+    let elf = workspace_dir
+        .join("target")
+        .join(spec.target)
+        .join("release")
+        .join(spec.bin);
+
+    if !elf.exists() {
+        bail!("expected ELF not found at {}", elf.display());
+    }
+
+    Ok(elf)
+}
+
+fn run_flash_and_monitor(elf: &PathBuf, port: Option<&str>) -> Result<()> {
+    eprintln!("ossm-flash: flashing {}", elf.display());
+
+    let mut cmd = Command::new("espflash");
+    cmd.arg("flash").arg("--monitor");
+    if let Some(p) = port {
+        cmd.arg("--port").arg(p);
+    }
+    cmd.arg(elf);
+
+    // Inherit stdio so the user sees espflash's progress bar and the chip's
+    // boot/log output live. espflash holds the serial FD across flash -> monitor
+    // internally, so we don't lose ROM-bootloader bytes.
+    cmd.stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit());
+
+    let status = cmd
+        .status()
+        .context("failed to invoke `espflash` (is it on PATH? `cargo install espflash`)")?;
+
+    if !status.success() {
+        bail!("espflash exited with status {status}");
+    }
+
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+    let spec = cli.variant.spec();
+    let motor = cli.motor.unwrap_or(spec.default_motor);
+
+    let elf = if cli.no_build {
+        let root = workspace_root()?;
+        root.join(spec.workspace)
+            .join("target")
+            .join(spec.target)
+            .join("release")
+            .join(spec.bin)
+    } else {
+        run_build(&spec, motor)?
+    };
+
+    if cli.build_only {
+        return Ok(());
+    }
+
+    run_flash_and_monitor(&elf, cli.port.as_deref())
+}

--- a/justfile
+++ b/justfile
@@ -5,41 +5,15 @@ set dotenv-load := true
 default:
     @just --list
 
-# OSSM Alt (ESP32-S3). Pass motor=sim to swap in the simulated motor.
-[working-directory: 'firmware/esp32s3']
-build-ossm-alt motor="rs485":
-    cargo +esp build --release --bin ossm-alt --features motor-{{ motor }}
+# Build a firmware variant. Variants: ossm-alt, waveshare, seeed-xiao, ossm-reference.
+# Pass `sim` as the second arg to swap in the simulated motor (e.g. `just build seeed-xiao sim`).
+build variant motor="":
+    cargo run --quiet -p ossm-flash -- {{ variant }} --build-only {{ if motor != "" { "--motor " + motor } else { "" } }}
 
-[working-directory: 'firmware/esp32s3']
-flash-ossm-alt motor="rs485":
-    cargo +esp run --release --bin ossm-alt --features motor-{{ motor }}
-
-# Waveshare ESP32-S3-RS485-CAN. Pass motor=sim to swap in the simulated motor.
-[working-directory: 'firmware/esp32s3']
-build-waveshare motor="rs485":
-    cargo +esp build --release --bin waveshare --features motor-{{ motor }}
-
-[working-directory: 'firmware/esp32s3']
-flash-waveshare motor="rs485":
-    cargo +esp run --release --bin waveshare --features motor-{{ motor }}
-
-# Seeed Studio XIAO ESP32-S3. Pass motor=sim to swap in the simulated motor.
-[working-directory: 'firmware/esp32s3']
-build-seeed-xiao motor="rs485":
-    cargo +esp build --release --bin seeed-xiao --features motor-{{ motor }}
-
-[working-directory: 'firmware/esp32s3']
-flash-seeed-xiao motor="rs485":
-    cargo +esp run --release --bin seeed-xiao --features motor-{{ motor }}
-
-# OSSM Reference (ESP32). Pass motor=sim to swap in the simulated motor.
-[working-directory: 'firmware/esp32']
-build-ossm-reference motor="stepdir":
-    cargo +esp build --release --bin ossm-reference --features motor-{{ motor }}
-
-[working-directory: 'firmware/esp32']
-flash-ossm-reference motor="stepdir":
-    cargo +esp run --release --bin ossm-reference --features motor-{{ motor }}
+# Build, flash, and monitor a firmware variant. Variants: ossm-alt, waveshare, seeed-xiao, ossm-reference.
+# Pass `sim` as the second arg to flash a build with the simulated motor.
+flash variant motor="":
+    cargo run --quiet -p ossm-flash -- {{ variant }} {{ if motor != "" { "--motor " + motor } else { "" } }}
 
 
 # WASM Simulator
@@ -67,7 +41,7 @@ web-tools: build-wasm
 
 # All
 [parallel]
-build-all: build-ossm-alt build-waveshare build-seeed-xiao build-ossm-reference build-wasm
+build-all: (build "ossm-alt") (build "waveshare") (build "seeed-xiao") (build "ossm-reference") build-wasm
 
 # Check that all required tools are installed
 [unix]


### PR DESCRIPTION
## Problem

We want to be able to own UART immediately after flashing

## Solution

Wrap espflash with a new builder and flasher crate

## Testing

`just flash ossm-alt` correctly builds, flashes and monitors