### PR TITLE
refactor(events): All inputs get demuxed into events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,6 +103,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "ble-remote"
+version = "0.1.0"
+dependencies = [
+ "bt-hci",
+ "embassy-executor",
+ "embassy-futures",
+ "embassy-sync 0.7.2",
+ "embassy-time",
+ "esp-radio",
+ "events",
+ "heapless 0.9.2",
+ "log",
+ "pattern-engine",
+ "portable-atomic",
+ "static_cell",
+ "trouble-host",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -848,6 +867,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "events"
+version = "0.1.0"
+dependencies = [
+ "embassy-sync 0.7.2",
+ "log",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1192,6 +1219,7 @@ dependencies = [
  "embassy-sync 0.7.2",
  "embassy-time",
  "esp-radio",
+ "events",
  "log",
  "pattern-engine",
  "portable-atomic",
@@ -1210,7 +1238,9 @@ version = "0.1.0"
 dependencies = [
  "embassy-futures",
  "embassy-sync 0.7.2",
+ "embassy-time",
  "embedded-hal-async",
+ "events",
  "log",
  "ossm",
 ]
@@ -1273,24 +1303,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "radr-remote"
-version = "0.1.0"
-dependencies = [
- "bt-hci",
- "embassy-executor",
- "embassy-futures",
- "embassy-sync 0.7.2",
- "embassy-time",
- "esp-radio",
- "heapless 0.9.2",
- "log",
- "pattern-engine",
- "portable-atomic",
- "static_cell",
- "trouble-host",
 ]
 
 [[package]]

--- a/bindings/trajectory-recorder/Cargo.lock
+++ b/bindings/trajectory-recorder/Cargo.lock
@@ -125,9 +125,9 @@ dependencies = [
 
 [[package]]
 name = "embassy-time-queue-utils"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe6ecec32eac4f98c5427904006b0fc61f77d350e1572530f744ef14650f7a1"
+checksum = "168297bf80aaf114b3c9ad589bf38b01b3009b9af7f97cd18086c5bbf96f5693"
 dependencies = [
  "embassy-executor-timer-queue",
  "heapless 0.9.2",
@@ -171,6 +171,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ff09972d4073aa8c299395be75161d582e7629cd663171d62af73c8d50dba3f"
 dependencies = [
  "embedded-io",
+]
+
+[[package]]
+name = "events"
+version = "0.1.0"
+dependencies = [
+ "embassy-sync",
+ "log",
 ]
 
 [[package]]
@@ -319,9 +327,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libm"
@@ -436,6 +444,7 @@ dependencies = [
  "embassy-sync",
  "embassy-time",
  "embedded-hal-async",
+ "events",
  "log",
  "ossm",
 ]

--- a/bindings/web-simulator/Cargo.lock
+++ b/bindings/web-simulator/Cargo.lock
@@ -174,6 +174,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "events"
+version = "0.1.0"
+dependencies = [
+ "embassy-sync",
+ "log",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -434,7 +442,9 @@ version = "0.1.0"
 dependencies = [
  "embassy-futures",
  "embassy-sync",
+ "embassy-time",
  "embedded-hal-async",
+ "events",
  "log",
  "ossm",
 ]

--- a/crates/ble-remote/Cargo.toml
+++ b/crates/ble-remote/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 
 [dependencies]
 pattern-engine = { path = "../pattern-engine" }
+events = { path = "../events" }
 
 embassy-sync = { version = "0.7", default-features = false }
 embassy-time = { version = "0.5.1" }

--- a/crates/ble-remote/src/lib.rs
+++ b/crates/ble-remote/src/lib.rs
@@ -19,7 +19,7 @@ use heapless::String;
 use log::{error, info, warn};
 use pattern_engine::{
     EngineState, PatternEngine, PatternInput,
-    commands::{self, InputCommand, PlaybackCommand},
+    commands::{self, PatternCmd},
 };
 use static_cell::StaticCell;
 use trouble_host::prelude::*;
@@ -197,7 +197,7 @@ pub async fn ble_events_task(
                     },
                 }
 
-                commands::dispatch_playback(engine, PlaybackCommand::Stop);
+                events::publish(PatternCmd::Stop);
                 info!("BLE session ended, stopping engine");
             }
             Err(err) => {
@@ -263,7 +263,7 @@ async fn gatt_events_task<P: PacketPool>(
                         let command: String<MAX_COMMAND_LENGTH> =
                             server.get(&server.ossm_service.primary_command)?;
 
-                        process_command(&command, server, engine);
+                        process_command(&command, server);
                     }
                     if event_handle == server.ossm_service.pattern_description.handle {
                         let command: String<MAX_PATTERN_LENGTH> =
@@ -385,11 +385,7 @@ fn state_to_json(state: EngineState, input: &PatternInput) -> String<MAX_STATE_L
     out
 }
 
-fn process_command(
-    command: &String<MAX_COMMAND_LENGTH>,
-    server: &Server<'_>,
-    engine: &'static PatternEngine,
-) {
+fn process_command(command: &String<MAX_COMMAND_LENGTH>, server: &Server<'_>) {
     info!("BLE Command {}", command);
 
     let mut split_command = command.split(":");
@@ -404,27 +400,14 @@ fn process_command(
                         if let Ok(value) = value.parse::<u32>() {
                             let normalized = value as f64 / 100.0;
                             match action {
-                                "speed" => commands::dispatch_input(
-                                    engine,
-                                    InputCommand::SetSpeed(normalized),
-                                ),
-                                "stroke" => commands::dispatch_input(
-                                    engine,
-                                    InputCommand::SetStroke(normalized),
-                                ),
-                                "depth" => commands::dispatch_input(
-                                    engine,
-                                    InputCommand::SetDepth(normalized),
-                                ),
-                                // BLE sends 0–100; internal range is -1.0..1.0.
-                                "sensation" => commands::dispatch_input(
-                                    engine,
-                                    InputCommand::SetSensation(normalized * 2.0 - 1.0),
-                                ),
-                                "pattern" => commands::dispatch_playback(
-                                    engine,
-                                    PlaybackCommand::Play(value as usize),
-                                ),
+                                "speed" => events::publish(PatternCmd::SetSpeed(normalized)),
+                                "stroke" => events::publish(PatternCmd::SetStroke(normalized)),
+                                "depth" => events::publish(PatternCmd::SetDepth(normalized)),
+                                // BLE sends 0-100; internal range is -1.0..1.0.
+                                "sensation" => {
+                                    events::publish(PatternCmd::SetSensation(normalized * 2.0 - 1.0))
+                                }
+                                "pattern" => events::publish(PatternCmd::Play(value as usize)),
                                 _ => {
                                     error!("Invalid set command {}", action);
                                     fail = true;
@@ -440,10 +423,8 @@ fn process_command(
                     }
                 }
                 "go" => match action {
-                    "simplePenetration" | "strokeEngine" => {
-                        commands::dispatch_playback(engine, PlaybackCommand::Play(0))
-                    }
-                    "menu" => commands::dispatch_playback(engine, PlaybackCommand::Stop),
+                    "simplePenetration" | "strokeEngine" => events::publish(PatternCmd::Play(0)),
+                    "menu" => events::publish(PatternCmd::Stop),
                     _ => {
                         error!("Unknown go action: {}", action);
                         fail = true;

--- a/crates/events/Cargo.toml
+++ b/crates/events/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "events"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+embassy-sync = { version = "0.7", default-features = false }
+log = "0.4"

--- a/crates/events/src/lib.rs
+++ b/crates/events/src/lib.rs
@@ -1,0 +1,174 @@
+//! Typed event bus.
+//!
+//! `events` is the single demux point for messages flowing between
+//! transports (BLE, ESP-NOW, UART, web) and the rest of the program.
+//! Each transport decodes its native protocol into typed events and
+//! publishes them through this crate. Whoever cares about those events
+//! subscribes; whoever doesn't, ignores.
+//!
+//! Adding a new event like this:
+//!
+//! ```ignore
+//! #[derive(Copy, Clone, Debug)]
+//! pub enum PatternCmd {
+//!     Play(usize),
+//!     Pause,
+//!     // ...
+//! }
+//! events::declare_event!(PatternCmd);
+//!
+//! // Publishing (transport side):
+//! events::publish(PatternCmd::Play(3));
+//!
+//! // Subscribing (consumer side):
+//! let mut cmds = events::subscribe::<PatternCmd>();
+//! loop {
+//!     let cmd = cmds.next().await;
+//!     // ...
+//! }
+//! ```
+#![no_std]
+
+use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
+use embassy_sync::pubsub::{PubSubChannel, Subscriber, WaitResult};
+
+/// Per-event-type slot count.
+///
+/// How many in-flight events a single subscriber can fall behind by
+/// before older events get dropped on its behalf. Sized for human-rate
+/// input - knob updates, button presses, mode switches.
+pub const SLOT_COUNT: usize = 8;
+
+/// Per-event-type subscriber cap.
+///
+/// Maximum number of concurrent subscribers across the whole program for
+/// a given event type.
+pub const SUBSCRIBER_COUNT: usize = 4;
+
+/// A typed event that flows through the input bus.
+///
+/// Use [`declare_event!`] to implement this trait and allocate the
+/// backing static channel in one step.
+pub trait Event: Copy + 'static {
+    fn channel() -> &'static EventChannel<Self>;
+}
+
+/// Backing storage for a single event type's pubsub.
+///
+/// Constructed once as a `static` per event type via [`declare_event!`].
+/// Not constructed by hand outside the macro.
+pub struct EventChannel<E: Clone + 'static> {
+    inner: PubSubChannel<CriticalSectionRawMutex, E, SLOT_COUNT, SUBSCRIBER_COUNT, 0>,
+}
+
+impl<E: Clone + 'static> EventChannel<E> {
+    pub const fn new() -> Self {
+        Self {
+            inner: PubSubChannel::new(),
+        }
+    }
+}
+
+impl<E: Clone + 'static> Default for EventChannel<E> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Active subscription to events of type `E`.
+///
+/// Drop the subscription to release its subscriber slot.
+pub struct Subscription<E: Event> {
+    sub: Subscriber<'static, CriticalSectionRawMutex, E, SLOT_COUNT, SUBSCRIBER_COUNT, 0>,
+}
+
+impl<E: Event> Subscription<E> {
+    /// Wait for the next event of type `E`.
+    pub async fn next(&mut self) -> E {
+        loop {
+            match self.sub.next_message().await {
+                WaitResult::Message(e) => return e,
+                WaitResult::Lagged(n) => {
+                    log::warn!(
+                        "events: subscription for {} lagged by {} events",
+                        core::any::type_name::<E>(),
+                        n,
+                    );
+                }
+            }
+        }
+    }
+}
+
+/// Publish an event to all current subscribers of its type.
+///
+/// Drops the oldest queued event for any subscriber whose slot is full.
+/// Drop-oldest is the right semantic for human-rate input: a stale depth
+/// value is worse than a missed one.
+pub fn publish<E: Event>(event: E) {
+    E::channel()
+        .inner
+        .immediate_publisher()
+        .publish_immediate(event);
+}
+
+/// Subscribe to events of type `E`.
+///
+/// Panics if the per-event-type subscriber cap ([`SUBSCRIBER_COUNT`]) is
+/// exhausted. This is a programming error; raise the cap if a real use
+/// case demands more concurrent subscribers.
+pub fn subscribe<E: Event>() -> Subscription<E> {
+    let sub = E::channel()
+        .inner
+        .subscriber()
+        .expect("events: too many subscribers - raise SUBSCRIBER_COUNT");
+    Subscription { sub }
+}
+
+/// Mode-framework extractor for the event bus.
+///
+/// A zero-sized handle that gates access to [`subscribe`] inside an
+/// extractor-style mode signature. Modes that listen for events take
+/// this in their argument list:
+///
+/// ```ignore
+/// async fn my_mode(motion: &MotionSender, input: Input) {
+///     let mut cmds = input.subscribe::<PatternCmd>();
+///     loop {
+///         let cmd = cmds.next().await;
+///         // ...
+///     }
+/// }
+/// ```
+///
+/// Outside the modes framework, call the free [`subscribe`] function
+/// directly - this type only exists to give the mode extractor pattern
+/// something to dispatch on.
+pub struct Input;
+
+impl Input {
+    /// Subscribe to events of type `E`. Identical to the free
+    /// [`subscribe`] function.
+    pub fn subscribe<E: Event>(&self) -> Subscription<E> {
+        subscribe::<E>()
+    }
+}
+
+/// Declare a type as an [`Event`] and allocate its backing channel.
+///
+/// Expands to a hidden `static EventChannel<T>` plus an `impl Event for T`.
+/// Place at module scope alongside the type definition. Calling twice
+/// for the same type fails to compile (duplicate `impl`).
+#[macro_export]
+macro_rules! declare_event {
+    ($ty:ty) => {
+        const _: () = {
+            static CHANNEL: $crate::EventChannel<$ty> = $crate::EventChannel::new();
+            impl $crate::Event for $ty {
+                fn channel() -> &'static $crate::EventChannel<Self> {
+                    &CHANNEL
+                }
+            }
+        };
+    };
+}

--- a/crates/ossm-m5-remote/Cargo.toml
+++ b/crates/ossm-m5-remote/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 
 [dependencies]
 pattern-engine = { path = "../pattern-engine" }
+events = { path = "../events" }
 
 embassy-sync = { version = "0.7", default-features = false }
 embassy-time = { version = "0.5.1" }

--- a/crates/ossm-m5-remote/src/lib.rs
+++ b/crates/ossm-m5-remote/src/lib.rs
@@ -10,10 +10,7 @@ use esp_radio::esp_now::{
     BROADCAST_ADDRESS, EspNowManager, EspNowReceiver, EspNowSender, PeerInfo,
 };
 use log::{error, info};
-use pattern_engine::{
-    PatternEngine,
-    commands::{self, InputCommand, PlaybackCommand},
-};
+use pattern_engine::commands::PatternCmd;
 use portable_atomic::{AtomicU32, AtomicU64};
 use zerocopy::{Immutable, IntoBytes, KnownLayout, TryFromBytes};
 
@@ -190,16 +187,15 @@ pub fn start(
     manager: &'static EspNowManager<'static>,
     sender: &'static Mutex<NoopRawMutex, EspNowSender<'static>>,
     receiver: EspNowReceiver<'static>,
-    engine: &'static PatternEngine,
     config: RemoteConfig,
 ) {
     spawner
-        .spawn(receiver_task(manager, sender, receiver, engine, config))
+        .spawn(receiver_task(manager, sender, receiver, config))
         .unwrap();
     spawner
         .spawn(heartbeat_send_task(manager, sender, config))
         .unwrap();
-    spawner.spawn(heartbeat_check_task(engine)).unwrap();
+    spawner.spawn(heartbeat_check_task()).unwrap();
 
     info!("ESP-NOW remote tasks started, waiting for connection...");
 }
@@ -209,7 +205,6 @@ async fn receiver_task(
     manager: &'static EspNowManager<'static>,
     sender: &'static Mutex<NoopRawMutex, EspNowSender<'static>>,
     mut receiver: EspNowReceiver<'static>,
-    engine: &'static PatternEngine,
     config: RemoteConfig,
 ) {
     info!("ESP-NOW receiver task started");
@@ -241,7 +236,7 @@ async fn receiver_task(
                 }
                 let current = CURRENT_PATTERN_IDX.load(Ordering::Acquire) as usize;
                 info!("Playing pattern {}", current);
-                commands::dispatch_playback(engine, PlaybackCommand::Play(current));
+                events::publish(PatternCmd::Play(current));
             }
             M5Command::Off => {
                 let ack = M5Packet {
@@ -255,25 +250,25 @@ async fn receiver_task(
                         error!("Could not send OFF ack: {}", err);
                     }
                 }
-                commands::dispatch_playback(engine, PlaybackCommand::Pause);
+                events::publish(PatternCmd::Pause);
                 info!("Paused");
             }
             M5Command::Speed => {
                 let velocity = (packet.value as f64) / config.max_velocity_mm_s;
-                commands::dispatch_input(engine, InputCommand::SetSpeed(velocity));
+                events::publish(PatternCmd::SetSpeed(velocity));
             }
             M5Command::Depth => {
                 let depth = (packet.value as f64) / config.max_travel_mm;
-                commands::dispatch_input(engine, InputCommand::SetDepth(depth));
+                events::publish(PatternCmd::SetDepth(depth));
             }
             M5Command::Stroke => {
                 let stroke = (packet.value as f64) / config.max_travel_mm;
-                commands::dispatch_input(engine, InputCommand::SetStroke(stroke));
+                events::publish(PatternCmd::SetStroke(stroke));
             }
             M5Command::Sensation => {
                 // Remote sends -100..100; pattern engine expects -1.0..1.0
                 let sensation = (packet.value as f64) / 100.0;
-                commands::dispatch_input(engine, InputCommand::SetSensation(sensation));
+                events::publish(PatternCmd::SetSensation(sensation));
             }
             M5Command::Pattern => {
                 let remote_idx = packet.value as u32;
@@ -281,10 +276,7 @@ async fn receiver_task(
                     let engine_idx = pattern.to_engine_index();
                     CURRENT_PATTERN_IDX.store(engine_idx, Ordering::Release);
                     info!("Switching to pattern {}", engine_idx);
-                    commands::dispatch_playback(
-                        engine,
-                        PlaybackCommand::Play(engine_idx as usize),
-                    );
+                    events::publish(PatternCmd::Play(engine_idx as usize));
                 }
             }
             M5Command::Heartbeat => {
@@ -338,7 +330,7 @@ async fn heartbeat_send_task(
 }
 
 #[embassy_executor::task]
-async fn heartbeat_check_task(engine: &'static PatternEngine) {
+async fn heartbeat_check_task() {
     info!("ESP-NOW heartbeat check task started");
 
     let mut ticker = Ticker::every(Duration::from_millis(1000));
@@ -357,7 +349,7 @@ async fn heartbeat_check_task(engine: &'static PatternEngine) {
 
         if was_connected && !is_connected {
             info!("Remote disconnected, heartbeat lost");
-            commands::dispatch_playback(engine, PlaybackCommand::Pause);
+            events::publish(PatternCmd::Pause);
         } else if !was_connected && is_connected {
             info!("Remote connected");
         }

--- a/crates/pattern-engine/Cargo.toml
+++ b/crates/pattern-engine/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 
 [dependencies]
 ossm = { path = "../../ossm" }
+events = { path = "../events" }
 embassy-sync = { version = "0.7", default-features = false }
 embassy-time = { version = "0.5", default-features = false }
 embedded-hal-async = "1.0"

--- a/crates/pattern-engine/src/commands.rs
+++ b/crates/pattern-engine/src/commands.rs
@@ -1,9 +1,38 @@
-//! Public API for remote adapters — the full surface a new remote needs.
+//! Public API for remote adapters
+//!
+//! Any new input device that wants to control the pattern engine should
+//! use these commands.
 
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_sync::pubsub::{self, Subscriber};
 
 use crate::{AnyPattern, EngineState, PatternEngine, PatternInput, PatternMeta};
+
+/// Unified pattern command. Flows through the `input` event bus.
+///
+/// Combines what used to split as `PlaybackCommand` (one-shot transitions:
+/// Play/Pause/Stop/Home) and `InputCommand` (continuous knob values:
+/// SetSpeed/SetDepth/SetStroke/SetSensation). Transports publish a single
+/// `PatternCmd` and the consumer side ([`dispatch_pattern_cmd`]) routes
+/// each variant into the engine.
+#[derive(Debug, Clone, Copy)]
+pub enum PatternCmd {
+    Play(usize),
+    Pause,
+    Resume,
+    Stop,
+    Home,
+    /// 0.0-1.0 (fraction of max velocity).
+    SetSpeed(f64),
+    /// 0.0-1.0 (fraction of depth).
+    SetStroke(f64),
+    /// 0.0-1.0 (fraction of machine range).
+    SetDepth(f64),
+    /// -1.0-1.0 (pattern-specific).
+    SetSensation(f64),
+}
+
+events::declare_event!(PatternCmd);
 
 #[derive(Debug, Clone, Copy)]
 pub enum PlaybackCommand {
@@ -17,14 +46,37 @@ pub enum PlaybackCommand {
 /// Input values are clamped to their valid range on dispatch.
 #[derive(Debug, Clone, Copy)]
 pub enum InputCommand {
-    /// 0.0–1.0 (fraction of max velocity).
+    /// 0.0-1.0 (fraction of max velocity).
     SetSpeed(f64),
-    /// 0.0–1.0 (fraction of depth).
+    /// 0.0-1.0 (fraction of depth).
     SetStroke(f64),
-    /// 0.0–1.0 (fraction of machine range).
+    /// 0.0-1.0 (fraction of machine range).
     SetDepth(f64),
-    /// -1.0–1.0 (pattern-specific).
+    /// -1.0-1.0 (pattern-specific).
     SetSensation(f64),
+}
+
+impl From<PlaybackCommand> for PatternCmd {
+    fn from(cmd: PlaybackCommand) -> Self {
+        match cmd {
+            PlaybackCommand::Play(i) => Self::Play(i),
+            PlaybackCommand::Pause => Self::Pause,
+            PlaybackCommand::Resume => Self::Resume,
+            PlaybackCommand::Stop => Self::Stop,
+            PlaybackCommand::Home => Self::Home,
+        }
+    }
+}
+
+impl From<InputCommand> for PatternCmd {
+    fn from(cmd: InputCommand) -> Self {
+        match cmd {
+            InputCommand::SetSpeed(v) => Self::SetSpeed(v),
+            InputCommand::SetStroke(v) => Self::SetStroke(v),
+            InputCommand::SetDepth(v) => Self::SetDepth(v),
+            InputCommand::SetSensation(v) => Self::SetSensation(v),
+        }
+    }
 }
 
 pub fn dispatch_playback(engine: &PatternEngine, cmd: PlaybackCommand) {
@@ -50,6 +102,41 @@ pub fn dispatch_input(engine: &PatternEngine, cmd: InputCommand) {
     });
 }
 
+/// Apply a single [`PatternCmd`] to a pattern engine.
+///
+/// The consumer side of the events bus. A long-running task subscribes
+/// to `PatternCmd` events and calls this for each one; semantically the
+/// same as `dispatch_playback` + `dispatch_input` together.
+pub fn dispatch_pattern_cmd(engine: &PatternEngine, cmd: PatternCmd) {
+    match cmd {
+        PatternCmd::Play(idx) => engine.play(idx),
+        PatternCmd::Pause => engine.pause(),
+        PatternCmd::Resume => engine.resume(),
+        PatternCmd::Stop => engine.stop(),
+        PatternCmd::Home => engine.home(),
+        PatternCmd::SetSpeed(v) => engine.input().sender().send_modify(|opt| {
+            if let Some(input) = opt {
+                input.velocity = v.clamp(0.0, 1.0);
+            }
+        }),
+        PatternCmd::SetStroke(v) => engine.input().sender().send_modify(|opt| {
+            if let Some(input) = opt {
+                input.stroke = v.clamp(0.0, 1.0);
+            }
+        }),
+        PatternCmd::SetDepth(v) => engine.input().sender().send_modify(|opt| {
+            if let Some(input) = opt {
+                input.depth = v.clamp(0.0, 1.0);
+            }
+        }),
+        PatternCmd::SetSensation(v) => engine.input().sender().send_modify(|opt| {
+            if let Some(input) = opt {
+                input.sensation = v.clamp(-1.0, 1.0);
+            }
+        }),
+    }
+}
+
 pub fn current_state(engine: &PatternEngine) -> EngineState {
     engine.state()
 }
@@ -63,9 +150,7 @@ pub fn pattern_list() -> &'static [PatternMeta] {
 }
 
 pub fn pattern_description(idx: usize) -> Option<&'static str> {
-    AnyPattern::BUILTIN_PATTERNS
-        .get(idx)
-        .map(|m| m.description)
+    AnyPattern::BUILTIN_PATTERNS.get(idx).map(|m| m.description)
 }
 
 pub type StateSubscriber<'a> = Subscriber<'a, CriticalSectionRawMutex, EngineState, 1, 8, 0>;

--- a/firmware/esp32/Cargo.lock
+++ b/firmware/esp32/Cargo.lock
@@ -68,6 +68,7 @@ dependencies = [
  "embassy-sync 0.7.2",
  "embassy-time",
  "esp-radio",
+ "events",
  "heapless 0.9.2",
  "log",
  "pattern-engine",
@@ -854,6 +855,7 @@ dependencies = [
  "esp-println",
  "esp-radio",
  "esp-rtos",
+ "events",
  "log",
  "ossm",
  "ossm-esp",
@@ -940,6 +942,14 @@ checksum = "1810d8ee4845ef87542af981e38eb80ab531d0ef1061e1486014ab7af74c337a"
 dependencies = [
  "critical-section",
  "vcell",
+]
+
+[[package]]
+name = "events"
+version = "0.1.0"
+dependencies = [
+ "embassy-sync 0.7.2",
+ "log",
 ]
 
 [[package]]
@@ -1314,6 +1324,7 @@ dependencies = [
  "embassy-sync 0.7.2",
  "embassy-time",
  "embedded-hal-async",
+ "events",
  "log",
  "ossm",
 ]

--- a/firmware/esp32/Cargo.toml
+++ b/firmware/esp32/Cargo.toml
@@ -24,6 +24,7 @@ path = "src/bin/ossm-reference.rs"
 ossm = { path = "../../ossm" }
 ossm-esp = { path = "../../ossm-esp", features = ["esp32"] }
 pattern-engine = { path = "../../crates/pattern-engine" }
+events = { path = "../../crates/events" }
 ble-remote = { path = "../../crates/ble-remote", features = ["esp32"] }
 
 esp-hal = { version = "~1.0", features = ["log-04", "esp32", "unstable"] }

--- a/firmware/esp32/src/lib.rs
+++ b/firmware/esp32/src/lib.rs
@@ -32,7 +32,10 @@ use esp_hal::{
 use esp_rtos::embassy::InterruptExecutor;
 use log::info;
 use ossm::{MechanicalConfig, MotionController, MotionLimits, Ossm};
-use pattern_engine::{AnyPattern, PatternEngine};
+use pattern_engine::{
+    AnyPattern, PatternEngine,
+    commands::{PatternCmd, dispatch_pattern_cmd},
+};
 use static_cell::StaticCell;
 
 extern crate alloc;
@@ -77,6 +80,20 @@ async fn motion_task(mut controller: MotionController<'static, board::Board>) {
             log::error!("Motion controller fault: {:?}", e);
         }
         ticker.next().await;
+    }
+}
+
+/// Drains [`PatternCmd`] events from the event bus into the pattern engine.
+///
+/// Transports (BLE today, ESP-NOW + UART later) publish typed events via
+/// `events::publish`. This task is the single consumer that translates
+/// each event into the engine's internal command/input channels.
+#[embassy_executor::task]
+async fn pattern_command_task() {
+    let mut cmds = events::subscribe::<PatternCmd>();
+    loop {
+        let cmd = cmds.next().await;
+        dispatch_pattern_cmd(&PATTERNS, cmd);
     }
 }
 
@@ -135,6 +152,8 @@ pub async fn run(spawner: Spawner, config: Config) {
     );
 
     radio::start(&spawner, config.bt, &PATTERNS);
+
+    spawner.spawn(pattern_command_task()).unwrap();
 
     let mut pattern_runner = PATTERNS.runner(AnyPattern::all_builtin());
     pattern_runner.run(Delay).await;

--- a/firmware/esp32s3/Cargo.lock
+++ b/firmware/esp32s3/Cargo.lock
@@ -68,6 +68,7 @@ dependencies = [
  "embassy-sync 0.7.2",
  "embassy-time",
  "esp-radio",
+ "events",
  "heapless 0.9.2",
  "log",
  "pattern-engine",
@@ -952,6 +953,7 @@ dependencies = [
  "esp-println",
  "esp-radio",
  "esp-rtos",
+ "events",
  "log",
  "ossm",
  "ossm-esp",
@@ -979,6 +981,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b4b8c4e4d9f187553ecdb7173edec7b2deb2beea106eedefecdb1654b8ee25a"
 dependencies = [
  "vcell",
+]
+
+[[package]]
+name = "events"
+version = "0.1.0"
+dependencies = [
+ "embassy-sync 0.7.2",
+ "log",
 ]
 
 [[package]]
@@ -1354,6 +1364,7 @@ dependencies = [
  "embassy-sync 0.7.2",
  "embassy-time",
  "esp-radio",
+ "events",
  "log",
  "pattern-engine",
  "portable-atomic",
@@ -1374,6 +1385,7 @@ dependencies = [
  "embassy-sync 0.7.2",
  "embassy-time",
  "embedded-hal-async",
+ "events",
  "log",
  "ossm",
 ]

--- a/firmware/esp32s3/Cargo.toml
+++ b/firmware/esp32s3/Cargo.toml
@@ -32,6 +32,7 @@ path = "src/bin/seeed-xiao.rs"
 ossm = { path = "../../ossm" }
 ossm-esp = { path = "../../ossm-esp", features = ["esp32s3"] }
 pattern-engine = { path = "../../crates/pattern-engine" }
+events = { path = "../../crates/events" }
 ossm-m5-remote = { path = "../../crates/ossm-m5-remote", features = [
     "esp32s3",
 ] }

--- a/firmware/esp32s3/src/lib.rs
+++ b/firmware/esp32s3/src/lib.rs
@@ -31,7 +31,10 @@ use esp_hal::{
 use esp_rtos::embassy::InterruptExecutor;
 use log::info;
 use ossm::{MechanicalConfig, MotionController, MotionLimits, Ossm};
-use pattern_engine::{AnyPattern, PatternEngine};
+use pattern_engine::{
+    AnyPattern, PatternEngine,
+    commands::{PatternCmd, dispatch_pattern_cmd},
+};
 use static_cell::StaticCell;
 
 extern crate alloc;
@@ -72,6 +75,21 @@ async fn motion_task(mut controller: MotionController<'static, board::Board>) {
             log::error!("Motion controller fault: {:?}", e);
         }
         ticker.next().await;
+    }
+}
+
+/// Drains [`PatternCmd`] events from the event bus into the pattern engine.
+///
+/// Transports (BLE today, ESP-NOW + UART later) publish typed events via
+/// `events::publish`. This task is the single consumer that translates
+/// each event into the engine's internal command/input channels. Without
+/// this task, published events sit in the bus and nothing happens.
+#[embassy_executor::task]
+async fn pattern_command_task() {
+    let mut cmds = events::subscribe::<PatternCmd>();
+    loop {
+        let cmd = cmds.next().await;
+        dispatch_pattern_cmd(&PATTERNS, cmd);
     }
 }
 
@@ -130,6 +148,8 @@ pub async fn run(spawner: Spawner, config: Config) {
     );
 
     radio::start(&spawner, config.wifi, config.bt, &PATTERNS, &limits);
+
+    spawner.spawn(pattern_command_task()).unwrap();
 
     let mut pattern_runner = PATTERNS.runner(AnyPattern::all_builtin());
     pattern_runner.run(Delay).await;

--- a/firmware/esp32s3/src/radio.rs
+++ b/firmware/esp32s3/src/radio.rs
@@ -48,7 +48,7 @@ pub fn start(
         max_travel_mm: limits.max_position_mm - limits.min_position_mm,
     };
 
-    ossm_m5_remote::start(spawner, manager, sender, receiver, patterns, remote_config);
+    ossm_m5_remote::start(spawner, manager, sender, receiver, remote_config);
 
     let connector =
         BleConnector::new(radio, bt, Default::default()).expect("Could not create BleConnector");


### PR DESCRIPTION
## Problem

Right now remotes are very tightly coupled to the things they interact with. This becomes and issue when trying to expand the feature set. We need to support RADR like remotes while also supporting ossm-rs remotes that have additional functionality (like configuring the device)

## Solution

Make a central event bus that decouples remotes and their targets. Running code can subscribe to events and remotes can publish to them.

## Testing

There should be no discernible difference in functionality. I've tested with ossm alt.