### PR TITLE
refactor(pattern-engine): Capability-split into Runner/Observer/Sender

### DIFF
--- a/bindings/web-simulator/src/lib.rs
+++ b/bindings/web-simulator/src/lib.rs
@@ -4,8 +4,8 @@ use alloc::string::String;
 use embassy_time::{Delay, Duration, Ticker};
 use ossm::{MechanicalConfig, MotionLimits, MotionObserver, Ossm};
 use pattern_engine::{
-    AnyPattern, PatternEngine,
-    commands::{self, InputCommand, PlaybackCommand},
+    AnyPattern, PatternEngine, PatternObserver, PatternSender,
+    commands,
 };
 use sim_board::SimBoard;
 use sim_motor::SimMotor;
@@ -13,7 +13,7 @@ use static_cell::StaticCell;
 use wasm_bindgen::prelude::*;
 
 static OSSM_CELL: StaticCell<Ossm> = StaticCell::new();
-static PATTERNS: PatternEngine = PatternEngine::new();
+static PATTERNS_CELL: StaticCell<PatternEngine> = StaticCell::new();
 
 static MECHANICAL: MechanicalConfig = MechanicalConfig {
     pulley_teeth: 20,
@@ -23,7 +23,9 @@ static MECHANICAL: MechanicalConfig = MechanicalConfig {
 
 #[wasm_bindgen]
 pub struct Simulator {
-    observer: MotionObserver,
+    motion_observer: MotionObserver,
+    pattern_observer: PatternObserver,
+    patterns: PatternSender,
 }
 
 #[wasm_bindgen]
@@ -36,7 +38,9 @@ impl Simulator {
 
         ossm::build_info!();
 
-        let (receiver, observer, motion) = OSSM_CELL.init(Ossm::new()).split();
+        let (receiver, motion_observer, motion) = OSSM_CELL.init(Ossm::new()).split();
+        let (runner, pattern_observer, patterns) =
+            PATTERNS_CELL.init(PatternEngine::new()).split();
 
         let update_interval_secs = update_interval_ms / 1000.0;
         let motor = SimMotor::new();
@@ -63,51 +67,54 @@ impl Simulator {
         });
 
         wasm_bindgen_futures::spawn_local(async move {
-            let mut pattern_runner = PATTERNS.runner(&motion, AnyPattern::all_builtin());
-            pattern_runner.run(Delay).await;
+            runner.run(&motion, AnyPattern::all_builtin(), Delay).await
         });
 
-        Self { observer }
+        Self {
+            motion_observer,
+            pattern_observer,
+            patterns,
+        }
     }
 
     pub fn get_engine_state(&self) -> u8 {
-        commands::current_state(&PATTERNS).as_u8()
+        self.pattern_observer.state().as_u8()
     }
 
     pub fn get_position(&self) -> f32 {
-        self.observer.state().position
+        self.motion_observer.state().position
     }
 
     pub fn set_depth(&self, depth: f64) {
-        commands::dispatch_input(&PATTERNS, InputCommand::SetDepth(depth));
+        self.patterns.set_depth(depth);
     }
 
     pub fn set_stroke(&self, stroke: f64) {
-        commands::dispatch_input(&PATTERNS, InputCommand::SetStroke(stroke));
+        self.patterns.set_stroke(stroke);
     }
 
     pub fn set_velocity(&self, velocity: f64) {
-        commands::dispatch_input(&PATTERNS, InputCommand::SetSpeed(velocity));
+        self.patterns.set_speed(velocity);
     }
 
     pub fn set_sensation(&self, sensation: f64) {
-        commands::dispatch_input(&PATTERNS, InputCommand::SetSensation(sensation));
+        self.patterns.set_sensation(sensation);
     }
 
     pub fn play(&self, index: usize) {
-        commands::dispatch_playback(&PATTERNS, PlaybackCommand::Play(index));
+        self.patterns.play(index);
     }
 
     pub fn pause(&self) {
-        commands::dispatch_playback(&PATTERNS, PlaybackCommand::Pause);
+        self.patterns.pause();
     }
 
     pub fn resume(&self) {
-        commands::dispatch_playback(&PATTERNS, PlaybackCommand::Resume);
+        self.patterns.resume();
     }
 
     pub fn stop(&self) {
-        commands::dispatch_playback(&PATTERNS, PlaybackCommand::Stop);
+        self.patterns.stop();
     }
 
     pub fn pattern_count(&self) -> usize {

--- a/crates/ble-remote/src/lib.rs
+++ b/crates/ble-remote/src/lib.rs
@@ -17,10 +17,7 @@ use embassy_time::{Duration, Ticker, Timer};
 use esp_radio::ble::controller::BleConnector;
 use heapless::String;
 use log::{error, info, warn};
-use pattern_engine::{
-    EngineState, PatternEngine, PatternInput,
-    commands::{self, InputCommand, PlaybackCommand},
-};
+use pattern_engine::{EngineState, PatternInput, PatternSender, commands};
 use static_cell::StaticCell;
 use trouble_host::prelude::*;
 
@@ -95,7 +92,11 @@ fn get_pattern_description(index: usize) -> String<MAX_PATTERN_LENGTH> {
     output
 }
 
-pub fn start(spawner: &Spawner, connector: BleConnector<'static>, engine: &'static PatternEngine) {
+pub fn start(
+    spawner: &Spawner,
+    connector: BleConnector<'static>,
+    patterns: &'static PatternSender,
+) {
     let bt_controller: ExternalController<_, 20> = ExternalController::new(connector);
 
     let resources = mk_static!(HostResources<DefaultPacketPool, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX>, HostResources::new());
@@ -113,7 +114,7 @@ pub fn start(spawner: &Spawner, connector: BleConnector<'static>, engine: &'stat
     } = stack.build();
 
     spawner.must_spawn(ble_runner_task(runner));
-    spawner.must_spawn(ble_events_task(stack, peripheral, engine));
+    spawner.must_spawn(ble_events_task(stack, peripheral, patterns));
 
     info!("BLE remote tasks started, waiting for connection...");
 }
@@ -130,7 +131,7 @@ pub async fn ble_events_task(
         ExternalController<BleConnector<'static>, 20>,
         DefaultPacketPool,
     >,
-    engine: &'static PatternEngine,
+    patterns: &'static PatternSender,
 ) {
     info!("Starting advertising and GATT service");
     let server = Server::new_with_config(GapConfig::Peripheral(PeripheralConfig {
@@ -182,8 +183,8 @@ pub async fn ble_events_task(
                     .with_attribute_server(&server)
                     .expect("Could not transform connection into GATT connection");
 
-                let events = gatt_events_task(&server, &gatt_connection, engine);
-                let notify = state_notifications(&server, &gatt_connection, engine);
+                let events = gatt_events_task(&server, &gatt_connection, patterns);
+                let notify = state_notifications(&server, &gatt_connection, patterns);
 
                 match select(events, notify).await {
                     Either::First(res) => {
@@ -197,7 +198,7 @@ pub async fn ble_events_task(
                     },
                 }
 
-                commands::dispatch_playback(engine, PlaybackCommand::Stop);
+                patterns.stop();
                 info!("BLE session ended, stopping engine");
             }
             Err(err) => {
@@ -221,7 +222,7 @@ pub async fn ble_runner_task(
 async fn gatt_events_task<P: PacketPool>(
     server: &Server<'_>,
     connection: &GattConnection<'_, '_, P>,
-    engine: &'static PatternEngine,
+    patterns: &'static PatternSender,
 ) -> Result<(), Error> {
     let reason = loop {
         match connection.next().await {
@@ -232,8 +233,8 @@ async fn gatt_events_task<P: PacketPool>(
                 match &event {
                     GattEvent::Read(event) => {
                         if event.handle() == server.ossm_service.current_state.handle {
-                            let engine_state = commands::current_state(engine);
-                            let input = commands::current_input(engine);
+                            let engine_state = patterns.state();
+                            let input = patterns.input();
                             let state_json = state_to_json(engine_state, &input);
                             server.set(&server.ossm_service.current_state, &state_json)?;
                         }
@@ -263,7 +264,7 @@ async fn gatt_events_task<P: PacketPool>(
                         let command: String<MAX_COMMAND_LENGTH> =
                             server.get(&server.ossm_service.primary_command)?;
 
-                        process_command(&command, server, engine);
+                        process_command(&command, server, patterns);
                     }
                     if event_handle == server.ossm_service.pattern_description.handle {
                         let command: String<MAX_PATTERN_LENGTH> =
@@ -331,19 +332,20 @@ async fn advertise<'values, 'server, C: Controller>(
 async fn state_notifications<P: PacketPool>(
     server: &Server<'_>,
     connection: &GattConnection<'_, '_, P>,
-    engine: &'static PatternEngine,
+    patterns: &'static PatternSender,
 ) -> Result<(), Error> {
-    let mut sub =
-        commands::subscribe_state(engine).expect("No state subscriber slots available");
+    let mut sub = patterns
+        .subscribe()
+        .expect("No state subscriber slots available");
     let mut heartbeat = Ticker::every(Duration::from_secs(1));
 
     loop {
         let engine_state = match select(sub.next_message_pure(), heartbeat.next()).await {
             Either::First(state) => state,
-            Either::Second(_) => commands::current_state(engine),
+            Either::Second(_) => patterns.state(),
         };
 
-        let input = commands::current_input(engine);
+        let input = patterns.input();
         let state_json = state_to_json(engine_state, &input);
         server
             .ossm_service
@@ -388,7 +390,7 @@ fn state_to_json(state: EngineState, input: &PatternInput) -> String<MAX_STATE_L
 fn process_command(
     command: &String<MAX_COMMAND_LENGTH>,
     server: &Server<'_>,
-    engine: &'static PatternEngine,
+    patterns: &'static PatternSender,
 ) {
     info!("BLE Command {}", command);
 
@@ -404,27 +406,12 @@ fn process_command(
                         if let Ok(value) = value.parse::<u32>() {
                             let normalized = value as f64 / 100.0;
                             match action {
-                                "speed" => commands::dispatch_input(
-                                    engine,
-                                    InputCommand::SetSpeed(normalized),
-                                ),
-                                "stroke" => commands::dispatch_input(
-                                    engine,
-                                    InputCommand::SetStroke(normalized),
-                                ),
-                                "depth" => commands::dispatch_input(
-                                    engine,
-                                    InputCommand::SetDepth(normalized),
-                                ),
+                                "speed" => patterns.set_speed(normalized),
+                                "stroke" => patterns.set_stroke(normalized),
+                                "depth" => patterns.set_depth(normalized),
                                 // BLE sends 0–100; internal range is -1.0..1.0.
-                                "sensation" => commands::dispatch_input(
-                                    engine,
-                                    InputCommand::SetSensation(normalized * 2.0 - 1.0),
-                                ),
-                                "pattern" => commands::dispatch_playback(
-                                    engine,
-                                    PlaybackCommand::Play(value as usize),
-                                ),
+                                "sensation" => patterns.set_sensation(normalized * 2.0 - 1.0),
+                                "pattern" => patterns.play(value as usize),
                                 _ => {
                                     error!("Invalid set command {}", action);
                                     fail = true;
@@ -440,10 +427,8 @@ fn process_command(
                     }
                 }
                 "go" => match action {
-                    "simplePenetration" | "strokeEngine" => {
-                        commands::dispatch_playback(engine, PlaybackCommand::Play(0))
-                    }
-                    "menu" => commands::dispatch_playback(engine, PlaybackCommand::Stop),
+                    "simplePenetration" | "strokeEngine" => patterns.play(0),
+                    "menu" => patterns.stop(),
                     _ => {
                         error!("Unknown go action: {}", action);
                         fail = true;

--- a/crates/ossm-m5-remote/src/lib.rs
+++ b/crates/ossm-m5-remote/src/lib.rs
@@ -10,10 +10,7 @@ use esp_radio::esp_now::{
     BROADCAST_ADDRESS, EspNowManager, EspNowReceiver, EspNowSender, PeerInfo,
 };
 use log::{error, info};
-use pattern_engine::{
-    PatternEngine,
-    commands::{self, InputCommand, PlaybackCommand},
-};
+use pattern_engine::PatternSender;
 use portable_atomic::{AtomicU32, AtomicU64};
 use zerocopy::{Immutable, IntoBytes, KnownLayout, TryFromBytes};
 
@@ -190,16 +187,16 @@ pub fn start(
     manager: &'static EspNowManager<'static>,
     sender: &'static Mutex<NoopRawMutex, EspNowSender<'static>>,
     receiver: EspNowReceiver<'static>,
-    engine: &'static PatternEngine,
+    patterns: &'static PatternSender,
     config: RemoteConfig,
 ) {
     spawner
-        .spawn(receiver_task(manager, sender, receiver, engine, config))
+        .spawn(receiver_task(manager, sender, receiver, patterns, config))
         .unwrap();
     spawner
         .spawn(heartbeat_send_task(manager, sender, config))
         .unwrap();
-    spawner.spawn(heartbeat_check_task(engine)).unwrap();
+    spawner.spawn(heartbeat_check_task(patterns)).unwrap();
 
     info!("ESP-NOW remote tasks started, waiting for connection...");
 }
@@ -209,7 +206,7 @@ async fn receiver_task(
     manager: &'static EspNowManager<'static>,
     sender: &'static Mutex<NoopRawMutex, EspNowSender<'static>>,
     mut receiver: EspNowReceiver<'static>,
-    engine: &'static PatternEngine,
+    patterns: &'static PatternSender,
     config: RemoteConfig,
 ) {
     info!("ESP-NOW receiver task started");
@@ -241,7 +238,7 @@ async fn receiver_task(
                 }
                 let current = CURRENT_PATTERN_IDX.load(Ordering::Acquire) as usize;
                 info!("Playing pattern {}", current);
-                commands::dispatch_playback(engine, PlaybackCommand::Play(current));
+                patterns.play(current);
             }
             M5Command::Off => {
                 let ack = M5Packet {
@@ -255,25 +252,25 @@ async fn receiver_task(
                         error!("Could not send OFF ack: {}", err);
                     }
                 }
-                commands::dispatch_playback(engine, PlaybackCommand::Pause);
+                patterns.pause();
                 info!("Paused");
             }
             M5Command::Speed => {
                 let velocity = (packet.value as f64) / config.max_velocity_mm_s;
-                commands::dispatch_input(engine, InputCommand::SetSpeed(velocity));
+                patterns.set_speed(velocity);
             }
             M5Command::Depth => {
                 let depth = (packet.value as f64) / config.max_travel_mm;
-                commands::dispatch_input(engine, InputCommand::SetDepth(depth));
+                patterns.set_depth(depth);
             }
             M5Command::Stroke => {
                 let stroke = (packet.value as f64) / config.max_travel_mm;
-                commands::dispatch_input(engine, InputCommand::SetStroke(stroke));
+                patterns.set_stroke(stroke);
             }
             M5Command::Sensation => {
                 // Remote sends -100..100; pattern engine expects -1.0..1.0
                 let sensation = (packet.value as f64) / 100.0;
-                commands::dispatch_input(engine, InputCommand::SetSensation(sensation));
+                patterns.set_sensation(sensation);
             }
             M5Command::Pattern => {
                 let remote_idx = packet.value as u32;
@@ -281,10 +278,7 @@ async fn receiver_task(
                     let engine_idx = pattern.to_engine_index();
                     CURRENT_PATTERN_IDX.store(engine_idx, Ordering::Release);
                     info!("Switching to pattern {}", engine_idx);
-                    commands::dispatch_playback(
-                        engine,
-                        PlaybackCommand::Play(engine_idx as usize),
-                    );
+                    patterns.play(engine_idx as usize);
                 }
             }
             M5Command::Heartbeat => {
@@ -338,7 +332,7 @@ async fn heartbeat_send_task(
 }
 
 #[embassy_executor::task]
-async fn heartbeat_check_task(engine: &'static PatternEngine) {
+async fn heartbeat_check_task(patterns: &'static PatternSender) {
     info!("ESP-NOW heartbeat check task started");
 
     let mut ticker = Ticker::every(Duration::from_millis(1000));
@@ -357,7 +351,7 @@ async fn heartbeat_check_task(engine: &'static PatternEngine) {
 
         if was_connected && !is_connected {
             info!("Remote disconnected, heartbeat lost");
-            commands::dispatch_playback(engine, PlaybackCommand::Pause);
+            patterns.pause();
         } else if !was_connected && is_connected {
             info!("Remote connected");
         }

--- a/crates/pattern-engine/src/commands.rs
+++ b/crates/pattern-engine/src/commands.rs
@@ -1,75 +1,43 @@
-//! Public API for remote adapters — the full surface a new remote needs.
+//! Public command vocabulary for the pattern engine.
+//!
+//! [`PatternCommand`] is the unified command type. Issue commands by
+//! constructing a `PatternCommand` and handing it to
+//! [`PatternSender::apply`](crate::PatternSender::apply), or call the
+//! per-action methods on [`PatternSender`](crate::PatternSender)
+//! directly for the same effect.
 
-use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
-use embassy_sync::pubsub::{self, Subscriber};
+use crate::{AnyPattern, PatternMeta};
 
-use crate::{AnyPattern, EngineState, PatternEngine, PatternInput, PatternMeta};
-
+/// Unified pattern command.
+///
+/// Combines one-shot playback transitions (`Play`/`Pause`/`Resume`/
+/// `Stop`/`Home`) with continuous input values (`SetSpeed`/`SetDepth`/
+/// `SetStroke`/`SetSensation`).
 #[derive(Debug, Clone, Copy)]
-pub enum PlaybackCommand {
+pub enum PatternCommand {
     Play(usize),
     Pause,
     Resume,
     Stop,
     Home,
-}
-
-/// Input values are clamped to their valid range on dispatch.
-#[derive(Debug, Clone, Copy)]
-pub enum InputCommand {
-    /// 0.0–1.0 (fraction of max velocity).
+    /// 0.0-1.0 (fraction of max velocity).
     SetSpeed(f64),
-    /// 0.0–1.0 (fraction of depth).
+    /// 0.0-1.0 (fraction of depth).
     SetStroke(f64),
-    /// 0.0–1.0 (fraction of machine range).
+    /// 0.0-1.0 (fraction of machine range).
     SetDepth(f64),
-    /// -1.0–1.0 (pattern-specific).
+    /// -1.0-1.0 (pattern-specific).
     SetSensation(f64),
 }
 
-pub fn dispatch_playback(engine: &PatternEngine, cmd: PlaybackCommand) {
-    match cmd {
-        PlaybackCommand::Play(idx) => engine.play(idx),
-        PlaybackCommand::Pause => engine.pause(),
-        PlaybackCommand::Resume => engine.resume(),
-        PlaybackCommand::Stop => engine.stop(),
-        PlaybackCommand::Home => engine.home(),
-    }
-}
-
-pub fn dispatch_input(engine: &PatternEngine, cmd: InputCommand) {
-    engine.input().sender().send_modify(|opt| {
-        if let Some(input) = opt {
-            match cmd {
-                InputCommand::SetSpeed(v) => input.velocity = v.clamp(0.0, 1.0),
-                InputCommand::SetStroke(v) => input.stroke = v.clamp(0.0, 1.0),
-                InputCommand::SetDepth(v) => input.depth = v.clamp(0.0, 1.0),
-                InputCommand::SetSensation(v) => input.sensation = v.clamp(-1.0, 1.0),
-            }
-        }
-    });
-}
-
-pub fn current_state(engine: &PatternEngine) -> EngineState {
-    engine.state()
-}
-
-pub fn current_input(engine: &PatternEngine) -> PatternInput {
-    engine.input().try_get().unwrap_or(PatternInput::DEFAULT)
-}
-
+/// Static list of built-in pattern metadata.
 pub fn pattern_list() -> &'static [PatternMeta] {
     &AnyPattern::BUILTIN_PATTERNS
 }
 
+/// Pattern description by index, if present.
 pub fn pattern_description(idx: usize) -> Option<&'static str> {
     AnyPattern::BUILTIN_PATTERNS
         .get(idx)
         .map(|m| m.description)
-}
-
-pub type StateSubscriber<'a> = Subscriber<'a, CriticalSectionRawMutex, EngineState, 1, 8, 0>;
-
-pub fn subscribe_state(engine: &PatternEngine) -> Result<StateSubscriber<'_>, pubsub::Error> {
-    engine.state_subscriber()
 }

--- a/crates/pattern-engine/src/engine.rs
+++ b/crates/pattern-engine/src/engine.rs
@@ -1,20 +1,16 @@
-use core::sync::atomic::{AtomicU16, Ordering};
+use core::sync::atomic::AtomicU16;
 
-use embassy_futures::select::{self, Either};
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_sync::channel::Channel;
-use embassy_sync::pubsub::{self, PubSubChannel};
-use embedded_hal_async::delay::DelayNs;
-use ossm::{MotionSender, StateResponse};
+use embassy_sync::pubsub::PubSubChannel;
 
-use log::info;
-
-use crate::AnyPattern;
 use crate::input::{PatternInput, SharedPatternInput};
-use crate::pattern::{Pattern, PatternCtx};
+use crate::observer::PatternObserver;
+use crate::runner::PatternRunner;
+use crate::sender::PatternSender;
 
 #[derive(Debug, Clone, Copy)]
-enum EngineCommand {
+pub(crate) enum EngineCommand {
     Play(usize),
     Stop,
     Home,
@@ -22,7 +18,7 @@ enum EngineCommand {
     Resume,
 }
 
-type EngineCommandChannel = Channel<CriticalSectionRawMutex, EngineCommand, 4>;
+pub(crate) type EngineCommandChannel = Channel<CriticalSectionRawMutex, EngineCommand, 4>;
 
 /// Observable state of the pattern engine.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -41,7 +37,7 @@ impl EngineState {
     const TAG_PAUSED: u8 = 3;
     const TAG_READY: u8 = 4;
 
-    const fn encode(self) -> u16 {
+    pub(crate) const fn encode(self) -> u16 {
         match self {
             Self::Idle => (Self::TAG_IDLE as u16) << 8,
             Self::Homing => (Self::TAG_HOMING as u16) << 8,
@@ -51,7 +47,7 @@ impl EngineState {
         }
     }
 
-    fn decode(v: u16) -> Self {
+    pub(crate) fn decode(v: u16) -> Self {
         let tag = (v >> 8) as u8;
         let idx = (v & 0xFF) as usize;
         match tag {
@@ -73,328 +69,53 @@ impl EngineState {
 
 /// Broadcast channel for [`EngineState`].
 ///
-/// Uses `PubSubChannel` so subscribers can be created and dropped
-/// dynamically as services start and stop.
-///
-/// - `CAP = 1`: only the latest transition matters; older messages are dropped.
+/// - `CAP = 1`: only the latest transition matters.
 /// - `SUBS = 8`: up to 8 concurrent async subscribers.
-/// - `PUBS = 0`: publishing uses [`PubSubChannel::immediate_publisher()`]
-///   which does not consume a publisher slot.
-type StateChannel = PubSubChannel<CriticalSectionRawMutex, EngineState, 1, 8, 0>;
+/// - `PUBS = 0`: publishing uses `immediate_publisher`.
+pub(crate) type StateChannel = PubSubChannel<CriticalSectionRawMutex, EngineState, 1, 8, 0>;
 
-struct PatternEngineChannels {
-    commands: EngineCommandChannel,
-    state: AtomicU16,
-}
-
-impl PatternEngineChannels {
-    const fn new() -> Self {
-        Self {
-            commands: EngineCommandChannel::new(),
-            state: AtomicU16::new(EngineState::Idle.encode()),
-        }
-    }
-
-    fn state(&self) -> EngineState {
-        EngineState::decode(self.state.load(Ordering::Relaxed))
-    }
-
-    fn store(&self, state: EngineState) {
-        self.state.store(state.encode(), Ordering::Relaxed);
-    }
-}
-
-/// Pattern engine that owns its command channels and shared input.
+/// Root container for a pattern engine.
 ///
-/// Create as a `static` and use `&'static PatternEngine` as the handle
-/// for sending commands and reading state. Construct a
-/// [`PatternEngineRunner`] via [`runner()`](Self::runner) and drive it
-/// with `.run(delay).await` - the runner is the active driver and is
-/// only alive for as long as the caller holds it.
-///
-/// The engine itself does **not** hold a [`MotionSender`]; it is just
-/// the channel layer that remotes push to. Motion is granted to the
-/// runner at construction time.
+/// Carries the command channel, shared pattern input, and state pubsub
+/// that the three capability handles project from. `PatternEngine` is
+/// instantiated once in static storage and immediately consumed by
+/// [`split`](Self::split). After split returns, nothing in the program
+/// holds an `&PatternEngine`: the three named capabilities cover every
+/// role.
 pub struct PatternEngine {
-    channels: PatternEngineChannels,
-    input: SharedPatternInput,
-    state_channel: StateChannel,
+    pub(crate) commands: EngineCommandChannel,
+    pub(crate) state: AtomicU16,
+    pub(crate) input: SharedPatternInput,
+    pub(crate) state_channel: StateChannel,
 }
 
 impl PatternEngine {
     pub const fn new() -> Self {
         Self {
-            channels: PatternEngineChannels::new(),
+            commands: EngineCommandChannel::new(),
+            state: AtomicU16::new(EngineState::Idle.encode()),
             input: SharedPatternInput::new_with(PatternInput::DEFAULT),
             state_channel: StateChannel::new(),
         }
     }
 
-    pub(crate) fn input(&self) -> &SharedPatternInput {
-        &self.input
-    }
-
-    pub(crate) fn state_subscriber(
-        &self,
-    ) -> Result<pubsub::Subscriber<'_, CriticalSectionRawMutex, EngineState, 1, 8, 0>, pubsub::Error>
-    {
-        self.state_channel.subscriber()
-    }
-
-    /// Build a runner bound to this engine and a [`MotionSender`].
+    /// Split into the three pattern-engine capabilities.
     ///
-    /// The runner is what actually drives motion. Constructing one
-    /// turns this engine "live"; drop it to stop driving.
-    pub fn runner<'m, const N: usize>(
-        &'m self,
-        motion: &'m MotionSender,
-        patterns: [AnyPattern; N],
-    ) -> PatternEngineRunner<'m, N> {
-        PatternEngineRunner {
-            engine: self,
-            motion,
-            patterns,
-            state: RunnerState::Idle,
-        }
-    }
-
-    pub(crate) fn play(&self, index: usize) {
-        let _ = self.channels.commands.try_send(EngineCommand::Play(index));
-    }
-
-    pub(crate) fn pause(&self) {
-        let _ = self.channels.commands.try_send(EngineCommand::Pause);
-    }
-
-    pub(crate) fn resume(&self) {
-        let _ = self.channels.commands.try_send(EngineCommand::Resume);
-    }
-
-    pub(crate) fn stop(&self) {
-        let _ = self.channels.commands.try_send(EngineCommand::Stop);
-        self.input.sender().send_modify(|opt| {
-            if let Some(input) = opt {
-                input.velocity = 0.0;
-            }
-        });
-    }
-
-    pub(crate) fn home(&self) {
-        let _ = self.channels.commands.try_send(EngineCommand::Home);
-    }
-
-    pub(crate) fn state(&self) -> EngineState {
-        self.channels.state()
-    }
-
-    fn publish_state(&self, state: EngineState) {
-        self.state_channel
-            .immediate_publisher()
-            .publish_immediate(state);
-    }
-}
-
-impl Default for PatternEngine {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-/// Internal runner state.
-#[derive(Debug, Clone, Copy)]
-enum RunnerState {
-    Idle,
-    Homing(Option<usize>),
-    Ready,
-    Playing(usize),
-}
-
-impl RunnerState {
-    fn as_engine_state(self) -> EngineState {
-        match self {
-            Self::Idle => EngineState::Idle,
-            Self::Homing(_) => EngineState::Homing,
-            Self::Ready => EngineState::Ready,
-            Self::Playing(idx) => EngineState::Playing(idx),
-        }
-    }
-}
-
-pub struct PatternEngineRunner<'m, const N: usize> {
-    engine: &'m PatternEngine,
-    motion: &'m MotionSender,
-    patterns: [AnyPattern; N],
-    state: RunnerState,
-}
-
-impl<'m, const N: usize> PatternEngineRunner<'m, N> {
-    /// Run the engine forever, processing commands and driving patterns.
+    /// Consumes a unique `&'static mut Self`, so it can be called at
+    /// most once: nothing in the program can produce a second
+    /// `&'static mut PatternEngine`. The expected boot shape is
+    /// `StaticCell::init(PatternEngine::new()).split()`.
     ///
-    /// `delay` must implement `Clone` so a fresh [`PatternCtx`] can be created
-    /// each time a pattern starts. All embassy `Delay` types are `Copy`.
-    pub async fn run<D: DelayNs + Clone>(&mut self, delay: D) -> ! {
-        let motion = self.motion;
-        let input = self.engine.input();
-
-        loop {
-            match self.state {
-                RunnerState::Idle | RunnerState::Ready => {
-                    let cmd = self.engine.channels.commands.receive().await;
-                    self.handle_command(cmd).await;
-                }
-                RunnerState::Homing(maybe_idx) => {
-                    if motion.enable().await != StateResponse::Completed {
-                        log::error!("Enable failed, returning to idle");
-                        self.set_state(RunnerState::Idle);
-                        continue;
-                    }
-
-                    let home_fut = motion.home();
-                    let mut home_fut = core::pin::pin!(home_fut);
-
-                    loop {
-                        let result = select::select(
-                            home_fut.as_mut(),
-                            self.engine.channels.commands.receive(),
-                        )
-                        .await;
-
-                        match result {
-                            Either::First(resp) => {
-                                if resp != StateResponse::Completed {
-                                    log::error!("Home failed, returning to idle");
-                                    self.set_state(RunnerState::Idle);
-                                } else {
-                                    match maybe_idx {
-                                        Some(idx) => self.set_state(RunnerState::Playing(idx)),
-                                        None => self.set_state(RunnerState::Ready),
-                                    }
-                                }
-                                break;
-                            }
-                            Either::Second(EngineCommand::Stop | EngineCommand::Pause) => {
-                                if motion.disable().await == StateResponse::Fault {
-                                    log::error!("Board fault during disable");
-                                }
-                                self.set_state(RunnerState::Idle);
-                                break;
-                            }
-                            Either::Second(_) => {}
-                        }
-                    }
-                }
-                RunnerState::Playing(idx) => {
-                    let mut ctx = PatternCtx::new(motion, input, delay.clone());
-
-                    let engine = self.engine;
-                    // Split borrows: the pinned future holds `patterns[idx]`,
-                    // so we access `engine` and `state` through separate refs.
-                    // This also means we cannot call `set_state()` here, so
-                    // transitions publish state directly via
-                    // `engine.publish_state()`.
-                    let state = &mut self.state;
-                    let pattern_fut = core::pin::pin!(self.patterns[idx].run(&mut ctx));
-                    let mut pattern_fut = pattern_fut;
-
-                    loop {
-                        let result = select::select(
-                            pattern_fut.as_mut(),
-                            engine.channels.commands.receive(),
-                        )
-                        .await;
-
-                        match result {
-                            Either::First(_result) => {
-                                if matches!(*state, RunnerState::Playing(_)) {
-                                    *state = RunnerState::Idle;
-                                    engine.channels.store(EngineState::Idle);
-                                    engine.publish_state(EngineState::Idle);
-                                }
-                                break;
-                            }
-                            Either::Second(cmd) => match cmd {
-                                EngineCommand::Pause => {
-                                    if motion.pause().await != StateResponse::Completed {
-                                        log::error!("Pause failed, stopping engine");
-                                        *state = RunnerState::Idle;
-                                        engine.channels.store(EngineState::Idle);
-                                        engine.publish_state(EngineState::Idle);
-                                        break;
-                                    }
-                                    engine.channels.store(EngineState::Paused(idx));
-                                    engine.publish_state(EngineState::Paused(idx));
-                                }
-                                EngineCommand::Resume => {
-                                    if motion.resume().await != StateResponse::Completed {
-                                        log::error!("Resume failed, stopping engine");
-                                        *state = RunnerState::Idle;
-                                        engine.channels.store(EngineState::Idle);
-                                        engine.publish_state(EngineState::Idle);
-                                        break;
-                                    }
-                                    engine.channels.store(EngineState::Playing(idx));
-                                    engine.publish_state(EngineState::Playing(idx));
-                                }
-                                EngineCommand::Play(i) if i == idx => {}
-                                EngineCommand::Play(new_idx) if new_idx < N => {
-                                    *state = RunnerState::Playing(new_idx);
-                                    engine.channels.store(EngineState::Playing(new_idx));
-                                    engine.publish_state(EngineState::Playing(new_idx));
-                                    break;
-                                }
-                                EngineCommand::Stop => {
-                                    if motion.disable().await == StateResponse::Fault {
-                                        log::error!("Board fault during disable");
-                                    }
-                                    *state = RunnerState::Idle;
-                                    engine.channels.store(EngineState::Idle);
-                                    engine.publish_state(EngineState::Idle);
-                                    break;
-                                }
-                                _ => {}
-                            },
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    fn set_state(&mut self, state: RunnerState) {
-        self.state = state;
-        let engine_state = state.as_engine_state();
-        info!("Engine state: {:?}", engine_state);
-        self.engine.channels.store(engine_state);
-        self.engine.publish_state(engine_state);
-    }
-
-    async fn handle_command(&mut self, cmd: EngineCommand) {
-        match cmd {
-            EngineCommand::Play(idx) => {
-                if idx < N {
-                    match self.state {
-                        RunnerState::Idle => self.set_state(RunnerState::Homing(Some(idx))),
-                        RunnerState::Homing(_) => {
-                            log::warn!("Ignoring Play command while homing");
-                        }
-                        _ => self.set_state(RunnerState::Playing(idx)),
-                    };
-                }
-            }
-            EngineCommand::Stop => {
-                if self.motion.disable().await == StateResponse::Fault {
-                    log::error!("Board fault during disable");
-                }
-                self.set_state(RunnerState::Idle);
-            }
-            EngineCommand::Home => {
-                if let RunnerState::Idle = self.state {
-                    self.set_state(RunnerState::Homing(None));
-                }
-            }
-            EngineCommand::Pause | EngineCommand::Resume => {
-                // Only handled inside the Playing inner loop.
-            }
-        }
+    /// - [`PatternRunner`] is the driver capability, consumed by
+    ///   [`run`](PatternRunner::run) to start the engine loop.
+    /// - [`PatternObserver`] is the read-only handle for state, input,
+    ///   and subscriptions.
+    /// - [`PatternSender`] is the command + input issuer.
+    pub fn split(&'static mut self) -> (PatternRunner, PatternObserver, PatternSender) {
+        (
+            PatternRunner::new(self),
+            PatternObserver::new(self),
+            PatternSender::new(self),
+        )
     }
 }

--- a/crates/pattern-engine/src/lib.rs
+++ b/crates/pattern-engine/src/lib.rs
@@ -3,13 +3,19 @@
 pub mod commands;
 mod engine;
 mod input;
+mod observer;
 mod pattern;
 pub mod patterns;
+mod runner;
+mod sender;
 mod util;
 
-pub use engine::{EngineState, PatternEngine, PatternEngineRunner};
+pub use engine::{EngineState, PatternEngine};
 pub use input::{PatternInput, SharedPatternInput};
+pub use observer::PatternObserver;
 pub use pattern::{Pattern, PatternCtx};
+pub use runner::PatternRunner;
+pub use sender::PatternSender;
 pub use util::scale;
 
 /// Public-facing metadata for a pattern.

--- a/crates/pattern-engine/src/observer.rs
+++ b/crates/pattern-engine/src/observer.rs
@@ -1,0 +1,49 @@
+use core::sync::atomic::Ordering;
+
+use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
+use embassy_sync::pubsub::{self, Subscriber};
+
+use crate::engine::{EngineState, PatternEngine};
+use crate::input::PatternInput;
+
+/// Read-only observer of the pattern engine.
+///
+/// Produced by [`PatternEngine::split`](crate::PatternEngine::split)
+/// alongside [`PatternSender`](crate::PatternSender) and
+/// [`PatternRunner`](crate::PatternRunner). Anyone with a borrow of
+/// the observer can read engine state, subscribe to state transitions,
+/// and read the current pattern input, but cannot issue commands.
+///
+/// Not [`Clone`] and not publicly constructible.
+pub struct PatternObserver {
+    engine: &'static PatternEngine,
+}
+
+impl PatternObserver {
+    pub(crate) fn new(engine: &'static PatternEngine) -> Self {
+        Self { engine }
+    }
+
+    /// Current engine state (idle, homing, playing, paused, ready).
+    pub fn state(&self) -> EngineState {
+        EngineState::decode(self.engine.state.load(Ordering::Relaxed))
+    }
+
+    /// Current pattern input (depth, stroke, velocity, sensation).
+    ///
+    /// Returns the default input if the watch has not been initialised
+    /// (i.e. nothing has set any value yet).
+    pub fn input(&self) -> PatternInput {
+        self.engine.input.try_get().unwrap_or(PatternInput::DEFAULT)
+    }
+
+    /// Subscribe to [`EngineState`] transitions.
+    ///
+    /// Returns `Err` if all subscriber slots are in use.
+    pub fn subscribe(
+        &self,
+    ) -> Result<Subscriber<'static, CriticalSectionRawMutex, EngineState, 1, 8, 0>, pubsub::Error>
+    {
+        self.engine.state_channel.subscriber()
+    }
+}

--- a/crates/pattern-engine/src/runner.rs
+++ b/crates/pattern-engine/src/runner.rs
@@ -1,0 +1,219 @@
+use core::sync::atomic::Ordering;
+
+use embassy_futures::select::{self, Either};
+use embedded_hal_async::delay::DelayNs;
+use log::info;
+use ossm::{MotionSender, StateResponse};
+
+use crate::AnyPattern;
+use crate::engine::{EngineCommand, EngineState, PatternEngine};
+use crate::pattern::{Pattern, PatternCtx};
+
+/// Internal runner state.
+#[derive(Debug, Clone, Copy)]
+enum RunnerState {
+    Idle,
+    Homing(Option<usize>),
+    Ready,
+    Playing(usize),
+}
+
+impl RunnerState {
+    fn as_engine_state(self) -> EngineState {
+        match self {
+            Self::Idle => EngineState::Idle,
+            Self::Homing(_) => EngineState::Homing,
+            Self::Ready => EngineState::Ready,
+            Self::Playing(idx) => EngineState::Playing(idx),
+        }
+    }
+}
+
+/// Driver capability for the pattern engine.
+///
+/// Produced by [`PatternEngine::split`](crate::PatternEngine::split).
+/// Drives the engine's main loop via [`run`](Self::run). The loop
+/// only returns if the host future is dropped (e.g. a mode switch),
+/// at which point the runner is free for another `run` call - each
+/// call starts fresh from the engine's current state.
+///
+/// The runner carries no state of its own; "currently running" is a
+/// property of the in-flight future, not the type. Spawning two
+/// concurrent `run`s on the same runner would compete for the engine's
+/// command channel; by convention only one caller (the active mode, or
+/// the firmware boot path) drives a runner at a time.
+pub struct PatternRunner {
+    engine: &'static PatternEngine,
+}
+
+impl PatternRunner {
+    pub(crate) fn new(engine: &'static PatternEngine) -> Self {
+        Self { engine }
+    }
+
+    /// Run the engine forever, processing commands and driving patterns.
+    ///
+    /// `motion` is borrowed for the lifetime of the run. `patterns` is
+    /// moved in and lives on the runner's stack frame. `delay` must be
+    /// `Clone` so a fresh [`PatternCtx`] can be created each time a
+    /// pattern starts (all embassy `Delay` types are `Copy`).
+    pub async fn run<const N: usize, D: DelayNs + Clone>(
+        &self,
+        motion: &MotionSender,
+        mut patterns: [AnyPattern; N],
+        delay: D,
+    ) -> ! {
+        let engine = self.engine;
+        let input = &engine.input;
+        let mut state = RunnerState::Idle;
+
+        loop {
+            match state {
+                RunnerState::Idle | RunnerState::Ready => {
+                    let cmd = engine.commands.receive().await;
+                    handle_command::<N>(engine, motion, cmd, &mut state).await;
+                }
+                RunnerState::Homing(maybe_idx) => {
+                    if motion.enable().await != StateResponse::Completed {
+                        log::error!("Enable failed, returning to idle");
+                        set_state(engine, &mut state, RunnerState::Idle);
+                        continue;
+                    }
+
+                    let home_fut = motion.home();
+                    let mut home_fut = core::pin::pin!(home_fut);
+
+                    loop {
+                        let result =
+                            select::select(home_fut.as_mut(), engine.commands.receive()).await;
+
+                        match result {
+                            Either::First(resp) => {
+                                if resp != StateResponse::Completed {
+                                    log::error!("Home failed, returning to idle");
+                                    set_state(engine, &mut state, RunnerState::Idle);
+                                } else {
+                                    match maybe_idx {
+                                        Some(idx) => {
+                                            set_state(engine, &mut state, RunnerState::Playing(idx))
+                                        }
+                                        None => set_state(engine, &mut state, RunnerState::Ready),
+                                    }
+                                }
+                                break;
+                            }
+                            Either::Second(EngineCommand::Stop | EngineCommand::Pause) => {
+                                if motion.disable().await == StateResponse::Fault {
+                                    log::error!("Board fault during disable");
+                                }
+                                set_state(engine, &mut state, RunnerState::Idle);
+                                break;
+                            }
+                            Either::Second(_) => {}
+                        }
+                    }
+                }
+                RunnerState::Playing(idx) => {
+                    let mut ctx = PatternCtx::new(motion, input, delay.clone());
+                    let pattern_fut = core::pin::pin!(patterns[idx].run(&mut ctx));
+                    let mut pattern_fut = pattern_fut;
+
+                    loop {
+                        let result =
+                            select::select(pattern_fut.as_mut(), engine.commands.receive()).await;
+
+                        match result {
+                            Either::First(_result) => {
+                                if matches!(state, RunnerState::Playing(_)) {
+                                    state = RunnerState::Idle;
+                                    store_and_publish(engine, EngineState::Idle);
+                                }
+                                break;
+                            }
+                            Either::Second(cmd) => match cmd {
+                                EngineCommand::Pause => {
+                                    if motion.pause().await != StateResponse::Completed {
+                                        log::error!("Pause failed, stopping engine");
+                                        state = RunnerState::Idle;
+                                        store_and_publish(engine, EngineState::Idle);
+                                        break;
+                                    }
+                                    store_and_publish(engine, EngineState::Paused(idx));
+                                }
+                                EngineCommand::Resume => {
+                                    if motion.resume().await != StateResponse::Completed {
+                                        log::error!("Resume failed, stopping engine");
+                                        state = RunnerState::Idle;
+                                        store_and_publish(engine, EngineState::Idle);
+                                        break;
+                                    }
+                                    store_and_publish(engine, EngineState::Playing(idx));
+                                }
+                                EngineCommand::Play(i) if i == idx => {}
+                                EngineCommand::Play(new_idx) if new_idx < N => {
+                                    state = RunnerState::Playing(new_idx);
+                                    store_and_publish(engine, EngineState::Playing(new_idx));
+                                    break;
+                                }
+                                EngineCommand::Stop => {
+                                    if motion.disable().await == StateResponse::Fault {
+                                        log::error!("Board fault during disable");
+                                    }
+                                    state = RunnerState::Idle;
+                                    store_and_publish(engine, EngineState::Idle);
+                                    break;
+                                }
+                                _ => {}
+                            },
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn set_state(engine: &PatternEngine, current: &mut RunnerState, new_state: RunnerState) {
+    *current = new_state;
+    let engine_state = new_state.as_engine_state();
+    info!("Engine state: {:?}", engine_state);
+    store_and_publish(engine, engine_state);
+}
+
+fn store_and_publish(engine: &PatternEngine, state: EngineState) {
+    engine.state.store(state.encode(), Ordering::Relaxed);
+    engine
+        .state_channel
+        .immediate_publisher()
+        .publish_immediate(state);
+}
+
+async fn handle_command<const N: usize>(
+    engine: &PatternEngine,
+    motion: &MotionSender,
+    cmd: EngineCommand,
+    state: &mut RunnerState,
+) {
+    match cmd {
+        EngineCommand::Play(idx) if idx < N => match *state {
+            RunnerState::Idle => set_state(engine, state, RunnerState::Homing(Some(idx))),
+            RunnerState::Homing(_) => log::warn!("Ignoring Play command while homing"),
+            _ => set_state(engine, state, RunnerState::Playing(idx)),
+        },
+        EngineCommand::Play(_) => {}
+        EngineCommand::Stop => {
+            if motion.disable().await == StateResponse::Fault {
+                log::error!("Board fault during disable");
+            }
+            set_state(engine, state, RunnerState::Idle);
+        }
+        EngineCommand::Home => {
+            if let RunnerState::Idle = *state {
+                set_state(engine, state, RunnerState::Homing(None));
+            }
+        }
+        EngineCommand::Pause | EngineCommand::Resume => {
+            // Only handled inside the Playing inner loop.
+        }
+    }
+}

--- a/crates/pattern-engine/src/sender.rs
+++ b/crates/pattern-engine/src/sender.rs
@@ -1,0 +1,136 @@
+use core::sync::atomic::Ordering;
+
+use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
+use embassy_sync::pubsub::{self, Subscriber};
+
+use crate::commands::PatternCommand;
+use crate::engine::{EngineCommand, EngineState, PatternEngine};
+use crate::input::PatternInput;
+
+/// Sender half of the pattern engine.
+///
+/// Holds the capability to issue engine commands (`play`, `pause`,
+/// `resume`, `stop`, `home`) and to mutate the live pattern input
+/// (`set_speed`, `set_depth`, `set_stroke`, `set_sensation`), plus the
+/// read methods from [`PatternObserver`](crate::PatternObserver) -
+/// command issuers almost always also need to read state to plan,
+/// and reading is harmless. Code that only needs to observe should
+/// still take `&PatternObserver` for the tighter contract.
+///
+/// Produced by [`PatternEngine::split`](crate::PatternEngine::split).
+/// Not [`Clone`] and not publicly constructible. The intended pattern
+/// is to hand `&PatternSender` (or own a static one) to every
+/// subsystem that needs to issue commands - typically the events-bus
+/// adapter that bridges `PatternCommand` into the engine.
+pub struct PatternSender {
+    engine: &'static PatternEngine,
+}
+
+impl PatternSender {
+    pub(crate) fn new(engine: &'static PatternEngine) -> Self {
+        Self { engine }
+    }
+
+    pub fn play(&self, index: usize) {
+        let _ = self.engine.commands.try_send(EngineCommand::Play(index));
+    }
+
+    pub fn pause(&self) {
+        let _ = self.engine.commands.try_send(EngineCommand::Pause);
+    }
+
+    pub fn resume(&self) {
+        let _ = self.engine.commands.try_send(EngineCommand::Resume);
+    }
+
+    pub fn stop(&self) {
+        let _ = self.engine.commands.try_send(EngineCommand::Stop);
+        self.engine.input.sender().send_modify(|opt| {
+            if let Some(input) = opt {
+                input.velocity = 0.0;
+            }
+        });
+    }
+
+    pub fn home(&self) {
+        let _ = self.engine.commands.try_send(EngineCommand::Home);
+    }
+
+    /// Set velocity as a fraction of max velocity. Clamped to `0.0..=1.0`.
+    pub fn set_speed(&self, value: f64) {
+        self.engine.input.sender().send_modify(|opt| {
+            if let Some(input) = opt {
+                input.velocity = value.clamp(0.0, 1.0);
+            }
+        });
+    }
+
+    /// Set stroke as a fraction of depth. Clamped to `0.0..=1.0`.
+    pub fn set_stroke(&self, value: f64) {
+        self.engine.input.sender().send_modify(|opt| {
+            if let Some(input) = opt {
+                input.stroke = value.clamp(0.0, 1.0);
+            }
+        });
+    }
+
+    /// Set depth as a fraction of machine range. Clamped to `0.0..=1.0`.
+    pub fn set_depth(&self, value: f64) {
+        self.engine.input.sender().send_modify(|opt| {
+            if let Some(input) = opt {
+                input.depth = value.clamp(0.0, 1.0);
+            }
+        });
+    }
+
+    /// Set sensation (pattern-specific). Clamped to `-1.0..=1.0`.
+    pub fn set_sensation(&self, value: f64) {
+        self.engine.input.sender().send_modify(|opt| {
+            if let Some(input) = opt {
+                input.sensation = value.clamp(-1.0, 1.0);
+            }
+        });
+    }
+
+    /// Apply a single [`PatternCommand`] - the bridge from the events bus.
+    ///
+    /// A long-running task subscribes to `PatternCommand` events and calls
+    /// `apply` for each one.
+    pub fn apply(&self, cmd: PatternCommand) {
+        match cmd {
+            PatternCommand::Play(idx) => self.play(idx),
+            PatternCommand::Pause => self.pause(),
+            PatternCommand::Resume => self.resume(),
+            PatternCommand::Stop => self.stop(),
+            PatternCommand::Home => self.home(),
+            PatternCommand::SetSpeed(v) => self.set_speed(v),
+            PatternCommand::SetStroke(v) => self.set_stroke(v),
+            PatternCommand::SetDepth(v) => self.set_depth(v),
+            PatternCommand::SetSensation(v) => self.set_sensation(v),
+        }
+    }
+
+    /// Current engine state (idle, homing, playing, paused, ready).
+    ///
+    /// `PatternSender` carries [`PatternObserver`](crate::PatternObserver)'s
+    /// read capability so command-issuing code can plan against current
+    /// state without also being handed an observer.
+    pub fn state(&self) -> EngineState {
+        EngineState::decode(self.engine.state.load(Ordering::Relaxed))
+    }
+
+    /// Current pattern input (depth, stroke, velocity, sensation).
+    pub fn input(&self) -> PatternInput {
+        self.engine.input.try_get().unwrap_or(PatternInput::DEFAULT)
+    }
+
+    /// Subscribe to [`EngineState`] transitions.
+    ///
+    /// Returns `Err` if all subscriber slots are in use.
+    pub fn subscribe(
+        &self,
+    ) -> Result<Subscriber<'static, CriticalSectionRawMutex, EngineState, 1, 8, 0>, pubsub::Error>
+    {
+        self.engine.state_channel.subscriber()
+    }
+}

--- a/firmware/esp32/src/lib.rs
+++ b/firmware/esp32/src/lib.rs
@@ -32,7 +32,7 @@ use esp_hal::{
 use esp_rtos::embassy::InterruptExecutor;
 use log::info;
 use ossm::{MechanicalConfig, MotionController, MotionLimits, Ossm};
-use pattern_engine::{AnyPattern, PatternEngine};
+use pattern_engine::{AnyPattern, PatternEngine, PatternSender};
 use static_cell::StaticCell;
 
 extern crate alloc;
@@ -48,7 +48,7 @@ macro_rules! mk_static {
 const UPDATE_INTERVAL_SECS: f64 = 0.01;
 
 static OSSM_CELL: StaticCell<Ossm> = StaticCell::new();
-static PATTERNS: PatternEngine = PatternEngine::new();
+static PATTERNS_CELL: StaticCell<PatternEngine> = StaticCell::new();
 
 static EXECUTOR_CORE_1: StaticCell<InterruptExecutor<2>> = StaticCell::new();
 // ESP32 DRAM is tighter than ESP32-S3. 16KB stack is needed for ruckig's
@@ -136,8 +136,10 @@ pub async fn run(spawner: Spawner, config: Config) {
         UPDATE_INTERVAL_SECS * 1000.0
     );
 
-    radio::start(&spawner, config.bt, &PATTERNS);
+    let (runner, _observer, patterns) = PATTERNS_CELL.init(PatternEngine::new()).split();
+    let patterns: &'static PatternSender = mk_static!(PatternSender, patterns);
 
-    let mut pattern_runner = PATTERNS.runner(&motion, AnyPattern::all_builtin());
-    pattern_runner.run(Delay).await;
+    radio::start(&spawner, config.bt, patterns);
+
+    runner.run(&motion, AnyPattern::all_builtin(), Delay).await
 }

--- a/firmware/esp32/src/radio.rs
+++ b/firmware/esp32/src/radio.rs
@@ -1,11 +1,11 @@
 use embassy_executor::Spawner;
 use esp_hal::peripherals::BT;
 use esp_radio::ble::controller::BleConnector;
-use pattern_engine::PatternEngine;
+use pattern_engine::PatternSender;
 
 use crate::mk_static;
 
-pub fn start(spawner: &Spawner, bt: BT<'static>, patterns: &'static PatternEngine) {
+pub fn start(spawner: &Spawner, bt: BT<'static>, patterns: &'static PatternSender) {
     let radio = &*mk_static!(
         esp_radio::Controller<'static>,
         esp_radio::init().expect("Failed to initialize radio controller")

--- a/firmware/esp32s3/src/lib.rs
+++ b/firmware/esp32s3/src/lib.rs
@@ -31,7 +31,7 @@ use esp_hal::{
 use esp_rtos::embassy::InterruptExecutor;
 use log::info;
 use ossm::{MechanicalConfig, MotionController, MotionLimits, Ossm};
-use pattern_engine::{AnyPattern, PatternEngine};
+use pattern_engine::{AnyPattern, PatternEngine, PatternSender};
 use static_cell::StaticCell;
 
 extern crate alloc;
@@ -47,7 +47,7 @@ macro_rules! mk_static {
 const UPDATE_INTERVAL_SECS: f64 = 0.01;
 
 static OSSM_CELL: StaticCell<Ossm> = StaticCell::new();
-static PATTERNS: PatternEngine = PatternEngine::new();
+static PATTERNS_CELL: StaticCell<PatternEngine> = StaticCell::new();
 
 static EXECUTOR_CORE_1: StaticCell<InterruptExecutor<2>> = StaticCell::new();
 static APP_CORE_STACK: StaticCell<Stack<32768>> = StaticCell::new();
@@ -131,8 +131,10 @@ pub async fn run(spawner: Spawner, config: Config) {
         UPDATE_INTERVAL_SECS * 1000.0
     );
 
-    radio::start(&spawner, config.wifi, config.bt, &PATTERNS, &limits);
+    let (runner, _observer, patterns) = PATTERNS_CELL.init(PatternEngine::new()).split();
+    let patterns: &'static PatternSender = mk_static!(PatternSender, patterns);
 
-    let mut pattern_runner = PATTERNS.runner(&motion, AnyPattern::all_builtin());
-    pattern_runner.run(Delay).await;
+    radio::start(&spawner, config.wifi, config.bt, patterns, &limits);
+
+    runner.run(&motion, AnyPattern::all_builtin(), Delay).await
 }

--- a/firmware/esp32s3/src/radio.rs
+++ b/firmware/esp32s3/src/radio.rs
@@ -7,7 +7,7 @@ use esp_radio::esp_now::{EspNowManager, EspNowSender};
 use log::info;
 use ossm::MotionLimits;
 use ossm_m5_remote::RemoteConfig;
-use pattern_engine::PatternEngine;
+use pattern_engine::PatternSender;
 
 use crate::mk_static;
 
@@ -15,7 +15,7 @@ pub fn start(
     spawner: &Spawner,
     wifi: WIFI<'static>,
     bt: BT<'static>,
-    patterns: &'static PatternEngine,
+    patterns: &'static PatternSender,
     limits: &MotionLimits,
 ) {
     let radio = &*mk_static!(


### PR DESCRIPTION
## Problem

The pattern engine was showing it's age too. The iterations have not been kind, it's internals are sound but it's api is confused.

## Solution

Implement the same splitting paradigm used for ossm core.

## Testing

No user facing changes
