### PR TITLE
fix(motion): Motion controller now has a clock to stop interrupt drift

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -498,6 +498,7 @@ dependencies = [
  "critical-section",
  "document-features",
  "embassy-time-driver",
+ "embassy-time-queue-utils",
  "embedded-hal 0.2.7",
  "embedded-hal 1.0.0",
  "embedded-hal-async",
@@ -511,6 +512,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ee71af1b3a0deaa53eaf2d39252f83504c853646e472400b763060389b9fcc9"
 dependencies = [
  "document-features",
+]
+
+[[package]]
+name = "embassy-time-queue-utils"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "168297bf80aaf114b3c9ad589bf38b01b3009b9af7f97cd18086c5bbf96f5693"
+dependencies = [
+ "embassy-executor-timer-queue",
+ "heapless 0.9.2",
 ]
 
 [[package]]
@@ -1183,6 +1194,8 @@ name = "ossm"
 version = "0.1.0"
 dependencies = [
  "crc",
+ "critical-section",
+ "embassy-futures",
  "embassy-sync 0.7.2",
  "embassy-time",
  "embedded-hal 1.0.0",

--- a/bindings/web-simulator/src/lib.rs
+++ b/bindings/web-simulator/src/lib.rs
@@ -2,7 +2,7 @@ extern crate alloc;
 use alloc::string::String;
 
 use embassy_time::{Delay, Duration, Ticker};
-use ossm::{MechanicalConfig, MotionLimits, MotionObserver, Ossm};
+use ossm::{EmbassyClock, MechanicalConfig, MotionLimits, MotionObserver, Ossm};
 use pattern_engine::{
     AnyPattern, PatternEngine, PatternObserver, PatternSender,
     commands,
@@ -52,7 +52,8 @@ impl Simulator {
             ..MotionLimits::default()
         };
 
-        let mut controller = receiver.into_controller(board, limits, update_interval_secs);
+        let mut controller =
+            receiver.into_controller(board, limits, update_interval_secs, EmbassyClock);
 
         let interval_us = (update_interval_secs * 1_000_000.0) as u64;
 

--- a/firmware/esp32/src/lib.rs
+++ b/firmware/esp32/src/lib.rs
@@ -31,7 +31,7 @@ use esp_hal::{
 };
 use esp_rtos::embassy::InterruptExecutor;
 use log::info;
-use ossm::{MechanicalConfig, MotionController, MotionLimits, Ossm};
+use ossm::{EmbassyClock, MechanicalConfig, MotionController, MotionLimits, Ossm};
 use pattern_engine::{AnyPattern, PatternEngine, PatternSender};
 use static_cell::StaticCell;
 
@@ -68,7 +68,7 @@ pub struct Config {
 }
 
 #[embassy_executor::task]
-async fn motion_task(mut controller: MotionController<'static, board::Board>) {
+async fn motion_task(mut controller: MotionController<'static, board::Board, EmbassyClock>) {
     let interval_us = (UPDATE_INTERVAL_SECS * 1_000_000.0) as u64;
     let mut ticker = Ticker::every(Duration::from_micros(interval_us));
 
@@ -104,7 +104,8 @@ pub async fn run(spawner: Spawner, config: Config) {
     let (receiver, _observer, motion) = OSSM_CELL.init(Ossm::new()).split();
 
     let board = board::build(motor, config.board, &MECHANICAL);
-    let controller = receiver.into_controller(board, limits.clone(), UPDATE_INTERVAL_SECS);
+    let controller =
+        receiver.into_controller(board, limits.clone(), UPDATE_INTERVAL_SECS, EmbassyClock);
 
     let sw_int = SoftwareInterruptControl::new(config.sw_int);
     let app_core_stack = APP_CORE_STACK.init(Stack::new());

--- a/firmware/esp32s3/src/lib.rs
+++ b/firmware/esp32s3/src/lib.rs
@@ -30,7 +30,7 @@ use esp_hal::{
 };
 use esp_rtos::embassy::InterruptExecutor;
 use log::info;
-use ossm::{MechanicalConfig, MotionController, MotionLimits, Ossm};
+use ossm::{EmbassyClock, MechanicalConfig, MotionController, MotionLimits, Ossm};
 use pattern_engine::{AnyPattern, PatternEngine, PatternSender};
 use static_cell::StaticCell;
 
@@ -63,7 +63,7 @@ pub struct Config {
 }
 
 #[embassy_executor::task]
-async fn motion_task(mut controller: MotionController<'static, board::Board>) {
+async fn motion_task(mut controller: MotionController<'static, board::Board, EmbassyClock>) {
     let interval_us = (UPDATE_INTERVAL_SECS * 1_000_000.0) as u64;
     let mut ticker = Ticker::every(Duration::from_micros(interval_us));
 
@@ -99,7 +99,8 @@ pub async fn run(spawner: Spawner, config: Config) {
     let (receiver, _observer, motion) = OSSM_CELL.init(Ossm::new()).split();
 
     let board = board::build(motor, &MECHANICAL);
-    let controller = receiver.into_controller(board, limits.clone(), UPDATE_INTERVAL_SECS);
+    let controller =
+        receiver.into_controller(board, limits.clone(), UPDATE_INTERVAL_SECS, EmbassyClock);
 
     let sw_int = SoftwareInterruptControl::new(config.sw_int);
     let app_core_stack = APP_CORE_STACK.init(Stack::new());

--- a/ossm/src/clock.rs
+++ b/ossm/src/clock.rs
@@ -1,0 +1,29 @@
+/// Monotonic time source for the [`MotionController`](crate::MotionController).
+///
+/// The controller *pulls* elapsed time from a `Clock` rather than trusting the
+/// caller to report it: a caller cannot pass a stale, doubled, or negative
+/// `dt`. Only differences between successive [`now_micros`](Clock::now_micros)
+/// readings are meaningful, and implementations **must be monotonic** (never
+/// return a smaller value than a previous call).
+///
+/// Injecting the clock (instead of calling `Instant::now()` directly) keeps the
+/// controller free of a hard dependency on a running time driver, so tests can
+/// drive it with controlled time via a fake clock.
+pub trait Clock {
+    /// A monotonically non-decreasing timestamp in microseconds.
+    fn now_micros(&self) -> u64;
+}
+
+/// [`Clock`] backed by `embassy_time::Instant`.
+///
+/// Requires an embassy-time driver to be installed by the final binary (the
+/// firmware crates and the wasm runtime both provide one). Zero-sized, so it
+/// costs nothing to store on the controller.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct EmbassyClock;
+
+impl Clock for EmbassyClock {
+    fn now_micros(&self) -> u64 {
+        embassy_time::Instant::now().as_micros()
+    }
+}

--- a/ossm/src/lib.rs
+++ b/ossm/src/lib.rs
@@ -1,9 +1,11 @@
 #![no_std]
+
 extern crate alloc;
 
 mod board;
 mod build_info;
 pub use build_info::BuildMeta;
+mod clock;
 mod command;
 mod limits;
 pub mod logging;
@@ -18,6 +20,7 @@ mod state;
 pub mod transport;
 
 pub use board::Board;
+pub use clock::{Clock, EmbassyClock};
 pub use command::{Cancelled, MotionCommand, StateCommand, StateResponse};
 use command::{MoveChannel, MoveResponseSignal, StateChannel, StateResponseSignal};
 pub use limits::MotionLimits;

--- a/ossm/src/motion.rs
+++ b/ossm/src/motion.rs
@@ -1,11 +1,17 @@
 use rsruckig::prelude::*;
 
+use crate::clock::Clock;
 use crate::command::{Cancelled, MotionCommand, StateCommand, StateResponse};
 use crate::state::MotionPhase;
 use crate::{Board, MotionLimits, Ossm};
 
 // Floor applied to velocity requests to prevent degenerate Ruckig inputs.
 const MIN_VELOCITY: f64 = 0.001;
+
+// If motion_control.tick has not called frequently enough, the resulting movement
+// is stale and potentially dangeroud. We allow the controller to fall behind by
+// this many ticks before faulting. With default values this is 12mm of travel.
+const STALL_FAULT_STEPS: u32 = 2;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 enum MotionState {
@@ -52,9 +58,22 @@ struct MotionTarget {
 /// No upstream code (patterns, UI, remote) can cause motion that exceeds
 /// these limits. The motor's internal trajectory planner is bypassed by
 /// configuring it for maximum tracking speed.
-pub struct MotionController<'a, B: Board> {
+///
+/// # Timing
+///
+/// Ruckig advances on a *fixed* timestep, but the control loop cannot be
+/// trusted to call [`update`](Self::update) at exactly that rate. The
+/// controller therefore pulls real elapsed time from its [`Clock`] and banks it
+/// in an accumulator, running as many fixed Ruckig steps as the elapsed time has
+/// earned. This makes `update` robust to the call interval: calling it faster
+/// than the timestep is a no-op, calling it slower runs multiple
+/// steps to stay on real time. If the gap so large it would move dangerously 
+/// STALL_FAULT_STEPS * max velocity, the controller faults to a safe stop.
+/// Correctness no longer depends on a precise tick call cadence.
+pub struct MotionController<'a, B: Board, C: Clock> {
     board: B,
     channels: &'a Ossm,
+    clock: C,
     state: MotionState,
     limits: MotionLimits,
     /// The last-instructed motion target. `Some` when a move has been commanded,
@@ -63,17 +82,28 @@ pub struct MotionController<'a, B: Board> {
     ruckig: Ruckig<1, ThrowErrorHandler>,
     input: InputParameter<1>,
     output: OutputParameter<1>,
+    /// The fixed Ruckig timestep in microseconds. One accumulator drain runs this
+    /// much trajectory time.
+    timestep_us: u64,
+    /// Real elapsed time (µs) banked but not yet consumed by a Ruckig step.
+    accumulator_us: u64,
+    /// Clock reading (µs) at the previous motion tick; `None` whenever no
+    /// trajectory is active, so idle/homing/paused gaps are never banked.
+    last_micros: Option<u64>,
 }
 
-impl<'a, B: Board> MotionController<'a, B> {
+impl<'a, B: Board, C: Clock> MotionController<'a, B, C> {
     /// Create a new `MotionController` in the `Disabled` state.
     ///
-    /// `update_interval_secs` must match the ticker period the caller uses.
-    /// Ruckig uses this as its fixed time step, so timing accuracy matters.
+    /// `timestep_secs` is Ruckig's fixed integration step. The control loop no
+    /// longer has to hit it exactly — the accumulator reconciles real elapsed
+    /// time (read from `clock`) against this step — but it should be a sensible
+    /// target cadence (e.g. 0.01 for 100 Hz).
     pub(crate) fn new(
         board: B,
         limits: MotionLimits,
-        update_interval_secs: f64,
+        timestep_secs: f64,
+        clock: C,
         channels: &'a Ossm,
     ) -> Self {
         let mut input = InputParameter::new(None);
@@ -88,12 +118,16 @@ impl<'a, B: Board> MotionController<'a, B> {
         Self {
             board,
             channels,
+            clock,
             state: MotionState::Disabled,
             limits,
             target: None,
-            ruckig: Ruckig::<1, ThrowErrorHandler>::new(None, update_interval_secs),
+            ruckig: Ruckig::<1, ThrowErrorHandler>::new(None, timestep_secs),
             input,
             output: OutputParameter::new(None),
+            timestep_us: ((timestep_secs * 1_000_000.0) as u64).max(1),
+            accumulator_us: 0,
+            last_micros: None,
         }
     }
 
@@ -220,19 +254,69 @@ impl<'a, B: Board> MotionController<'a, B> {
         }
     }
 
-    /// Sample the ruckig trajectory and send the position to the board.
+    /// Advance the ruckig trajectory by however much real time has elapsed, then
+    /// send the latest sampled position to the board.
+    ///
+    /// Time is pulled from [`self.clock`](Clock), not the caller, and banked in
+    /// the accumulator. We run one fixed Ruckig step per `timestep` of banked
+    /// time, so the trajectory tracks wall-clock regardless of how often this is
+    /// called — fast calls bank too little to step (no-op), slow calls run
+    /// several. A large enough gap faults instead of dangerously lurching.
     async fn tick(&mut self) -> Result<(), B::Error> {
         if !matches!(self.state, MotionState::Moving | MotionState::Stopping(_)) {
+            // No active trajectory: stop the clock so the idle gap is never
+            // banked into the next move, and start the next one from a clean slate.
+            self.last_micros = None;
+            self.accumulator_us = 0;
             return Ok(());
         }
 
-        let Ok(result) = self.ruckig.update(&self.input, &mut self.output) else {
+        let now = self.clock.now_micros();
+        let dt_us = match self.last_micros {
+            // saturating_sub guards against a non-monotonic clock; the first tick
+            // of a trajectory has no elapsed time.
+            Some(prev) => now.saturating_sub(prev),
+            None => 0,
+        };
+        self.last_micros = Some(now);
+
+        if dt_us > STALL_FAULT_STEPS as u64 * self.timestep_us {
+            log::error!(
+                "Motion loop starved: {}ms since last tick exceeds {} steps; faulting",
+                dt_us / 1_000,
+                STALL_FAULT_STEPS
+            );
+            self.enter_fault();
+            return Ok(());
+        }
+
+        self.accumulator_us += dt_us;
+
+        // Run as many fixed steps as the banked time has earned. If less than one
+        // timestep has elapsed, the loop body never runs and tick() is a no-op.
+        let mut last_result = None;
+        while self.accumulator_us >= self.timestep_us {
+            let Ok(result) = self.ruckig.update(&self.input, &mut self.output) else {
+                self.accumulator_us = 0;
+                return Ok(());
+            };
+            self.accumulator_us -= self.timestep_us;
+            if !matches!(result, RuckigResult::Working | RuckigResult::Finished) {
+                return Ok(());
+            }
+            // Feed each sub-step's result back so the next sub-step continues
+            // from it.
+            self.output.pass_to_input(&mut self.input);
+            let finished = matches!(result, RuckigResult::Finished);
+            last_result = Some(result);
+            if finished {
+                break;
+            }
+        }
+
+        let Some(result) = last_result else {
             return Ok(());
         };
-
-        if !matches!(result, RuckigResult::Working | RuckigResult::Finished) {
-            return Ok(());
-        }
 
         let mm = self.output.new_position[0]
             .clamp(self.limits.min_position_mm, self.limits.max_position_mm);
@@ -241,10 +325,12 @@ impl<'a, B: Board> MotionController<'a, B> {
             self.enter_fault();
             return Err(e);
         }
-        self.output.pass_to_input(&mut self.input);
         self.publish_state();
 
         if result == RuckigResult::Finished {
+            // Discard any sub-timestep remainder; the resulting state decides
+            // what (if anything) moves next.
+            self.accumulator_us = 0;
             match self.state {
                 MotionState::Stopping(StopReason::Pause) => {
                     self.transition(MotionState::Paused);

--- a/ossm/src/receiver.rs
+++ b/ossm/src/receiver.rs
@@ -1,4 +1,4 @@
-use crate::{Board, MotionController, MotionLimits, Ossm};
+use crate::{Board, Clock, MotionController, MotionLimits, Ossm};
 
 /// Receiver half of the motion channels.
 ///
@@ -34,13 +34,14 @@ impl MotionReceiver {
     /// physically powered and under the controller's command until the
     /// firmware loses power. There is no `Drop` path that disables the
     /// motor.
-    pub fn into_controller<B: Board>(
+    pub fn into_controller<B: Board, C: Clock>(
         self,
         board: B,
         limits: MotionLimits,
-        update_interval_secs: f64,
-    ) -> MotionController<'static, B> {
-        MotionController::new(board, limits, update_interval_secs, self.channels)
+        timestep_secs: f64,
+        clock: C,
+    ) -> MotionController<'static, B, C> {
+        MotionController::new(board, limits, timestep_secs, clock, self.channels)
     }
 }
 


### PR DESCRIPTION
## Problem

If, during homing, a user modifies the speed, the initial movements after the home are faster than they should be before returning to the correct speed.

## Solution

When homing the interval that calls the motion controller tick is paused. This queues up those ticks and all fire at once when the homing completes.

This change shifts the onus of timekeeping to the motion controller - it will check how long it's been since it's last call and decide if it should catch up or if it should fault.

This fixes two issues:

* The interval being called too frequently is now a noop - the motion controller ignores them if not enough time has passed.
* The interval is called after a small wait - the motion controller allows the motor to catch up giving it a new further destination 
* The interval is called way after the previous one - the motion controller refuses to continue and faults.

## Technical choices

* The clock is a trait rather than providing embassy time directly. This should make unit testing later much easier.
* The tick is now idempotent and should remain so going forward. The result of calling it should be safe regardless of frequency.

## Testing

The original bug as described has been tested on an ossm-alt with brake chopper and is resolved.
Sending with a small and large gap has been tested on the same device but synthetically - both passed.
