### PR TITLE
feat(stepdir): Adds pcnt counting for stepdir motors

### DIFF
--- a/firmware/esp32/Cargo.lock
+++ b/firmware/esp32/Cargo.lock
@@ -1286,6 +1286,7 @@ dependencies = [
 name = "ossm-esp"
 version = "0.1.0"
 dependencies = [
+ "critical-section",
  "embassy-time",
  "embedded-hal-async",
  "embedded-io 0.6.1",

--- a/firmware/esp32/Cargo.lock
+++ b/firmware/esp32/Cargo.lock
@@ -1284,6 +1284,7 @@ dependencies = [
 name = "ossm-esp"
 version = "0.1.0"
 dependencies = [
+ "critical-section",
  "embassy-time",
  "embedded-hal-async",
  "embedded-io 0.6.1",

--- a/firmware/esp32/src/bin/ossm-reference.rs
+++ b/firmware/esp32/src/bin/ossm-reference.rs
@@ -11,6 +11,7 @@ async fn main(spawner: embassy_executor::Spawner) {
 
     let config = esp32::Config {
         motor: esp32::MotorConfig {
+            pcnt: p.PCNT,
             rmt: p.RMT,
             step: p.GPIO14.into(),
             dir: p.GPIO27.into(),

--- a/firmware/esp32s3/Cargo.lock
+++ b/firmware/esp32s3/Cargo.lock
@@ -1334,6 +1334,7 @@ dependencies = [
 name = "ossm-esp"
 version = "0.1.0"
 dependencies = [
+ "critical-section",
  "embassy-time",
  "embedded-io 0.6.1",
  "esp-hal",

--- a/firmware/esp32s3/Cargo.lock
+++ b/firmware/esp32s3/Cargo.lock
@@ -1332,6 +1332,7 @@ dependencies = [
 name = "ossm-esp"
 version = "0.1.0"
 dependencies = [
+ "critical-section",
  "embassy-time",
  "embedded-io 0.6.1",
  "esp-hal",

--- a/ossm-esp/Cargo.toml
+++ b/ossm-esp/Cargo.toml
@@ -20,6 +20,7 @@ ossm = { path = "../ossm" }
 esp-hal = { version = "~1.0", default-features = false, features = ["unstable"] }
 embedded-io = "0.6.1"
 embassy-time = "0.5.1"
+critical-section = "1.2"
 
 # motor-rs485
 m57aim-motor = { path = "../drivers/m57aim", optional = true }

--- a/ossm-esp/src/motor/mod.rs
+++ b/ossm-esp/src/motor/mod.rs
@@ -2,6 +2,9 @@
 pub mod rs485;
 
 #[cfg(feature = "motor-stepdir")]
+pub mod pcnt;
+
+#[cfg(feature = "motor-stepdir")]
 pub mod stepdir;
 
 #[cfg(feature = "motor-sim")]

--- a/ossm-esp/src/motor/pcnt.rs
+++ b/ossm-esp/src/motor/pcnt.rs
@@ -1,0 +1,146 @@
+use core::cell::RefCell;
+use core::sync::atomic::{AtomicI32, Ordering};
+
+use critical_section::Mutex;
+use esp_hal::{
+    gpio::interconnect::PeripheralInput,
+    handler,
+    interrupt::Priority,
+    pcnt::{
+        channel::{CtrlMode, EdgeMode},
+        unit::{Counter, Unit},
+        Pcnt,
+    },
+};
+use ossm::PositionFeedback;
+
+/// Watermarks are placed symmetrically around zero, well inside the
+/// i16 counter range. When the hardware counter hits +HIGH_LIMIT or
+/// -HIGH_LIMIT it resets itself to 0 and fires an interrupt; the ISR
+/// folds that same amount into the extension counter so the
+/// composite position is continuous.
+const HIGH_LIMIT: i16 = 30_000;
+const LOW_LIMIT: i16 = -30_000;
+
+/// PCNT unit 0 is the only one we hand out today. If we ever need a
+/// second motor we promote this module to be generic over the unit.
+static UNIT: Mutex<RefCell<Option<Unit<'static, 0>>>> = Mutex::new(RefCell::new(None));
+
+/// Extension counter managed by the ISR. Combined with the
+/// hardware counter to form the full i32 position.
+static EXTENSION: AtomicI32 = AtomicI32::new(0);
+
+/// Hardware-counted position source.
+///
+/// Wires the STEP output signal into PCNT's edge input and the DIR
+/// output signal into PCNT's control input. The hardware counts every
+/// rising edge of STEP, with the count direction determined by DIR.
+/// Watermark interrupts extend the 16-bit hardware counter into a
+/// full i32 transparently.
+///
+/// The motion-task caller only ever sees the [`PositionFeedback`]
+/// trait; the wrap-extension math lives entirely behind this type.
+pub struct PcntPositionCounter {
+    counter: Counter<'static, 0>,
+}
+
+impl PcntPositionCounter {
+    /// Build a counter from the PCNT peripheral and the two signals to
+    /// observe. `step_signal` should be the STEP line (rising edges
+    /// trigger counting); `dir_signal` should be the DIR line (its
+    /// level selects increment vs decrement).
+    ///
+    /// Consumes the whole `Pcnt`; only unit 0 is used. If we need to use
+    /// others in the future, refactor to take a single Pcnt or expose them
+    pub fn new(
+        mut pcnt: Pcnt<'static>,
+        step_signal: impl PeripheralInput<'static>,
+        dir_signal: impl PeripheralInput<'static>,
+    ) -> Self {
+        pcnt.set_interrupt_handler(on_pcnt);
+
+        let unit = pcnt.unit0;
+        unit.set_low_limit(Some(LOW_LIMIT))
+            .expect("LOW_LIMIT is negative");
+        unit.set_high_limit(Some(HIGH_LIMIT))
+            .expect("HIGH_LIMIT is positive");
+        unit.clear();
+
+        let channel = &unit.channel0;
+        channel.set_edge_signal(step_signal);
+        channel.set_ctrl_signal(dir_signal);
+        // DIR low reverses the edge mode, DIR high keeps it; so with
+        // base "increment on rising, hold on falling" the unit counts
+        // up while DIR is high and down while DIR is low. This must
+        // match the convention in StepDirMotor::set_absolute_position.
+        channel.set_input_mode(EdgeMode::Hold, EdgeMode::Increment);
+        channel.set_ctrl_mode(CtrlMode::Reverse, CtrlMode::Keep);
+
+        unit.listen();
+        unit.resume();
+
+        let counter = unit.counter.clone();
+        critical_section::with(|cs| {
+            UNIT.borrow_ref_mut(cs).replace(unit);
+        });
+
+        Self { counter }
+    }
+}
+
+impl PositionFeedback for PcntPositionCounter {
+    fn position(&self) -> i32 {
+        // Triple-read: extension, counter, extension. A mismatch means
+        // the ISR fired between our two extension loads, so the
+        // counter value we captured doesn't belong to either snapshot.
+        // Retry until we see a consistent pair.
+        loop {
+            let before = EXTENSION.load(Ordering::Acquire);
+            let raw = self.counter.get() as i32;
+            let after = EXTENSION.load(Ordering::Acquire);
+            if before == after {
+                return before + raw;
+            }
+        }
+    }
+
+    fn reset(&mut self, value: i32) {
+        // Homing is the only caller and the motor is stationary while
+        // it runs, so the small window between clear() and the
+        // extension store is safe. We still pause+resume to keep the
+        // hardware from latching a stray edge mid-reset.
+        critical_section::with(|cs| {
+            if let Some(unit) = UNIT.borrow_ref(cs).as_ref() {
+                unit.pause();
+                unit.clear();
+                EXTENSION.store(value, Ordering::Release);
+                unit.resume();
+            }
+        });
+    }
+
+    fn applied(&mut self, _delta: i32) {
+        // PCNT observes the pulses directly; software bookkeeping is
+        // unused.
+    }
+}
+
+/// Run the pcnt interrupt on very high priority, it executes very quickly
+/// and is important for positional correctness
+#[handler(priority = Priority::Priority3)]
+fn on_pcnt() {
+    critical_section::with(|cs| {
+        if let Some(unit) = UNIT.borrow_ref(cs).as_ref() {
+            if !unit.interrupt_is_set() {
+                return;
+            }
+            let events = unit.events();
+            if events.high_limit {
+                EXTENSION.fetch_add(HIGH_LIMIT as i32, Ordering::Release);
+            } else if events.low_limit {
+                EXTENSION.fetch_add(LOW_LIMIT as i32, Ordering::Release);
+            }
+            unit.reset_interrupt();
+        }
+    });
+}

--- a/ossm-esp/src/motor/stepdir.rs
+++ b/ossm-esp/src/motor/stepdir.rs
@@ -3,13 +3,16 @@ use core::fmt::{self, Debug};
 use embassy_time::Delay;
 use esp_hal::{
     Blocking,
-    gpio::{AnyPin, Level, Output, OutputConfig},
-    peripherals::RMT,
+    gpio::{AnyPin, Flex, Level, Output, OutputConfig},
+    pcnt::Pcnt,
+    peripherals::{PCNT, RMT},
     rmt::{Channel, PulseCode, Rmt, Tx, TxChannelConfig, TxChannelCreator},
     time::Rate,
 };
 use m57aim_motor::{Motor57AIM, Motor57AIMConfig};
-use ossm::{SoftwarePositionCounter, StepDirConfig, StepDirMotor, StepOutput};
+use ossm::{StepDirConfig, StepDirMotor, StepOutput};
+
+use crate::motor::pcnt::PcntPositionCounter;
 
 /// RMT clock divider. With a statically set 80 MHz base clock,
 /// divider=4 gives 20 MHz (50 ns per tick).
@@ -25,33 +28,44 @@ const STEP_BATCH_SIZE: usize = 63;
 
 pub struct Config {
     pub rmt: RMT<'static>,
+    pub pcnt: PCNT<'static>,
     pub step: AnyPin<'static>,
     pub dir: AnyPin<'static>,
     pub enable: AnyPin<'static>,
 }
 
 pub type Motor = Motor57AIM<
-    StepDirMotor<RmtStepOutput, Output<'static>, Output<'static>, SoftwarePositionCounter>,
+    StepDirMotor<RmtStepOutput, Flex<'static>, Output<'static>, PcntPositionCounter>,
     Delay,
 >;
 
 pub fn build(config: Config) -> Motor {
     let rmt = Rmt::new(config.rmt, Rate::from_mhz(80)).expect("Failed to initialize RMT");
+    let pcnt = Pcnt::new(config.pcnt);
     let tx_config = TxChannelConfig::default().with_clk_divider(RMT_CLK_DIVIDER);
+
+    let step = Flex::new(config.step);
+    let (step_in, step_out) = step.split();
     let rmt_channel = rmt
         .channel0
-        .configure_tx(config.step, tx_config)
+        .configure_tx(step_out, tx_config)
         .expect("Failed to configure RMT TX channel");
 
     let step_output = RmtStepOutput::new(rmt_channel);
-    let dir_pin = Output::new(config.dir, Level::Low, OutputConfig::default());
+
+    let mut dir = Flex::new(config.dir);
+    dir.set_level(Level::Low);
+    dir.apply_output_config(&OutputConfig::default());
+    dir.set_output_enable(true);
+    let dir_ctrl = dir.peripheral_input();
+
     let enable_pin = Output::new(config.enable, Level::High, OutputConfig::default());
 
     let step_dir_motor = StepDirMotor::new(
         step_output,
-        dir_pin,
+        dir,
         enable_pin,
-        SoftwarePositionCounter::new(),
+        PcntPositionCounter::new(pcnt, step_in, dir_ctrl),
         StepDirConfig::default(),
     );
 


### PR DESCRIPTION
Ref #162

## Problem

When using step/dir motors, we count the number of pulses we have asked the RMT to send. If we cancel the set_absolute_position future, this count is incorrect.

## Solution

Utilise the pcnt modules to count pulses on the step line writed to the RMT to track position. The pcnt registers in the esp32 family are 16-bit so software extension is needed. i32 is exposed transparently to firmware. The dir feeds into pcnt's control input so direction automatically increments and decrements counts correctly.

## Testing

Flash ossm-reference and tracking works as intended. Ran some tests measuring offsets from end stops to ensure no dropped pulses.
