### PR TITLE
feat(m57aim): Adds baudrate auto configure on build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1112,6 +1112,7 @@ version = "0.1.0"
 dependencies = [
  "embedded-hal 1.0.0",
  "embedded-hal-async",
+ "log",
  "ossm",
 ]
 

--- a/drivers/m57aim/Cargo.toml
+++ b/drivers/m57aim/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2024"
 ossm = { path = "../../ossm" }
 embedded-hal = "1.0"
 embedded-hal-async = "1.0"
+log = "0.4"

--- a/drivers/m57aim/src/lib.rs
+++ b/drivers/m57aim/src/lib.rs
@@ -4,6 +4,7 @@ mod rs485;
 mod stepdir;
 
 pub use ossm::{Modbus, ModbusTransport};
+pub use rs485::provision;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(u16)]
@@ -56,8 +57,38 @@ impl Default for Motor57AIMConfig {
 }
 
 pub const DEFAULT_DEVICE_ADDR: u8 = 0x01;
-pub const STOCK_BAUD_RATE: u32 = 19_200;
-pub const TARGET_BAUD_RATE: u32 = 115_200;
+
+/// Baud rate that the motor ships with from the factory.
+pub const STOCK_BAUD_RATE: MotorBaudRate = MotorBaudRate::Baud19200;
+
+/// Baud rate the firmware uses at runtime. Provisioned into the motor
+/// once via [`Motor57AIM::set_baud_rate`] when first encountered at the
+/// stock rate; persists across power cycles thereafter.
+pub const TARGET_BAUD_RATE: MotorBaudRate = MotorBaudRate::Baud115200;
+
+/// 57AIM baud rate. The discriminants are the motor's magic register
+/// codes used when writing the baud through the provisioning sequence,
+/// not the integer baud itself - call [`MotorBaudRate::as_int`] for
+/// the actual UART rate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u16)]
+pub enum MotorBaudRate {
+    Baud9600 = 800,
+    Baud19200 = 801,
+    Baud38400 = 802,
+    Baud115200 = 803,
+}
+
+impl MotorBaudRate {
+    pub const fn as_int(self) -> u32 {
+        match self {
+            MotorBaudRate::Baud9600 => 9_600,
+            MotorBaudRate::Baud19200 => 19_200,
+            MotorBaudRate::Baud38400 => 38_400,
+            MotorBaudRate::Baud115200 => 115_200,
+        }
+    }
+}
 
 /// 57AIM BLDC servo motor, generic over communication interface and delay.
 pub struct Motor57AIM<I, D> {

--- a/drivers/m57aim/src/rs485.rs
+++ b/drivers/m57aim/src/rs485.rs
@@ -1,7 +1,19 @@
 use embedded_hal_async::delay::DelayNs;
-use ossm::{Motor, Rs485Motor, SelfHoming};
+use ossm::{Motor, Rs485Motor, SelfHoming, UartReconfigure};
 
-use crate::{Modbus, ModbusTransport, Motor57AIM, RoRegister, RwRegister};
+use crate::{
+    Modbus, ModbusTransport, Motor57AIM, Motor57AIMConfig, MotorBaudRate, RoRegister, RwRegister,
+    STOCK_BAUD_RATE, TARGET_BAUD_RATE,
+};
+
+/// Time to wait after UART comes up before the first probe. Gives the
+/// motor a chance to finish its own boot and start listening.
+const MOTOR_BOOT_DELAY_MS: u32 = 500;
+
+/// Settle window after switching the host UART to the stock baud rate
+/// before issuing the baud-provisioning sequence to the motor. Lets the
+/// motor drop any garbage it saw at the wrong baud.
+const POST_DOWNSHIFT_SETTLE_MS: u32 = 100;
 
 const SET_ABSOLUTE_POSITION_FUNC: u8 = 0x7B;
 const HOME_SPEED_RPM: u16 = 80;
@@ -89,6 +101,22 @@ impl<T: ModbusTransport, D> Motor57AIM<Modbus<T>, D> {
             .await
     }
 
+    /// Provision a new persistent baud rate on the motor.
+    ///
+    /// This is a one-shot setup: after the magic sequence the motor
+    /// stores the rate to its EEPROM and will only respond at the new
+    /// rate after a power cycle. The final `ModbusEnable=506` write
+    /// triggers the apply step and never sees a response, so its
+    /// error is intentionally discarded.
+    pub async fn set_baud_rate(&mut self, baud_rate: MotorBaudRate) -> Result<(), T::Error> {
+        self.write_register(RwRegister::ModbusEnable, 1).await?;
+        self.write_register(RwRegister::MotorAcceleration, baud_rate as u16)
+            .await?;
+        self.write_register(RwRegister::WeakMagneticAngle, 129).await?;
+        let _ = self.write_register(RwRegister::ModbusEnable, 506).await;
+        Ok(())
+    }
+
     /// Configure the motor for maximum tracking performance.
     ///
     /// Sets speed, acceleration, and output to maximum so the motor acts
@@ -137,6 +165,60 @@ impl<T: ModbusTransport, D> Motor57AIM<Modbus<T>, D> {
     pub async fn read_alarm_code(&mut self) -> Result<u16, T::Error> {
         self.read_register(RoRegister::AlarmCode as u16).await
     }
+}
+
+/// Bring up a 57AIM motor from a freshly opened RS-485 transport.
+///
+/// Waits for the motor to finish booting, probes at [`TARGET_BAUD_RATE`],
+/// and on success returns a ready-to-use motor wrapper. If the motor is
+/// silent at the target rate this drops the host UART to
+/// [`STOCK_BAUD_RATE`], writes the baud-provisioning sequence, and
+/// panics - the motor needs a physical power cycle for the new rate to
+/// take effect.
+pub async fn provision<T, D>(
+    transport: T,
+    device_addr: u8,
+    motor_config: Motor57AIMConfig,
+    delay: D,
+) -> Motor57AIM<Modbus<T>, D>
+where
+    T: ModbusTransport + UartReconfigure,
+    D: DelayNs,
+{
+    let mut motor = Motor57AIM::new(Modbus::new(transport, device_addr), motor_config, delay);
+    motor.delay.delay_ms(MOTOR_BOOT_DELAY_MS).await;
+
+    if motor.read_absolute_position().await.is_ok() {
+        log::info!("Motor responsive at {} baud", TARGET_BAUD_RATE.as_int());
+        return motor;
+    }
+
+    log::error!(
+        "Motor unresponsive at {} baud; falling back to {} baud to provision",
+        TARGET_BAUD_RATE.as_int(),
+        STOCK_BAUD_RATE.as_int()
+    );
+
+    if motor
+        .interface
+        .transport
+        .reconfigure_baud(STOCK_BAUD_RATE.as_int())
+        .await
+        .is_err()
+    {
+        panic!("Failed to reconfigure UART to stock baud");
+    }
+    motor.delay.delay_ms(POST_DOWNSHIFT_SETTLE_MS).await;
+
+    if motor.set_baud_rate(TARGET_BAUD_RATE).await.is_err() {
+        panic!("Failed to write target baud to motor");
+    }
+
+    log::error!(
+        "Motor baud rate provisioned to {}. Power cycle the motor to apply.",
+        TARGET_BAUD_RATE.as_int()
+    );
+    panic!("Power cycle required after motor baud provisioning");
 }
 
 impl<T: ModbusTransport, D: DelayNs> Motor for Motor57AIM<Modbus<T>, D> {

--- a/firmware/esp32/Cargo.lock
+++ b/firmware/esp32/Cargo.lock
@@ -1213,6 +1213,7 @@ version = "0.1.0"
 dependencies = [
  "embedded-hal 1.0.0",
  "embedded-hal-async",
+ "log",
  "ossm",
 ]
 

--- a/firmware/esp32s3/Cargo.lock
+++ b/firmware/esp32s3/Cargo.lock
@@ -1252,6 +1252,7 @@ version = "0.1.0"
 dependencies = [
  "embedded-hal 1.0.0",
  "embedded-hal-async",
+ "log",
  "ossm",
 ]
 

--- a/firmware/esp32s3/src/lib.rs
+++ b/firmware/esp32s3/src/lib.rs
@@ -87,7 +87,7 @@ pub async fn run(spawner: Spawner, config: Config) {
     let timg0 = TimerGroup::new(config.timg0);
     esp_rtos::start(timg0.timer0);
 
-    let motor = motor::build(config.motor);
+    let motor = motor::build(config.motor).await;
 
     static MECHANICAL: MechanicalConfig = MechanicalConfig {
         pulley_teeth: 20,

--- a/ossm-esp/src/motor/rs485.rs
+++ b/ossm-esp/src/motor/rs485.rs
@@ -3,7 +3,7 @@ use esp_hal::gpio::AnyPin;
 use esp_hal::peripherals::UART1;
 use esp_hal::uart::{Config as UartConfig, Uart};
 use m57aim_motor::{
-    Modbus, Motor57AIM, Motor57AIMConfig, DEFAULT_DEVICE_ADDR, TARGET_BAUD_RATE,
+    provision, Modbus, Motor57AIM, Motor57AIMConfig, DEFAULT_DEVICE_ADDR, TARGET_BAUD_RATE,
 };
 use rs485_board::Rs485ModbusTransport;
 
@@ -19,8 +19,8 @@ pub struct Config {
 pub type Transport = Rs485ModbusTransport<NonBlockingUart<'static>, Delay>;
 pub type Motor = Motor57AIM<Modbus<Transport>, Delay>;
 
-pub fn build(config: Config) -> Motor {
-    let uart_config = UartConfig::default().with_baudrate(TARGET_BAUD_RATE);
+pub async fn build(config: Config) -> Motor {
+    let uart_config = UartConfig::default().with_baudrate(TARGET_BAUD_RATE.as_int());
     let uart = Uart::new(config.uart1, uart_config)
         .expect("Failed to initialize UART")
         .with_tx(config.uart_tx)
@@ -32,9 +32,11 @@ pub fn build(config: Config) -> Motor {
     unsafe { crate::rs485::enable_uart1_rs485(config.rs485_de) };
 
     let transport = Rs485ModbusTransport::new(NonBlockingUart(uart), Delay);
-    Motor57AIM::new(
-        Modbus::new(transport, DEFAULT_DEVICE_ADDR),
+    provision(
+        transport,
+        DEFAULT_DEVICE_ADDR,
         Motor57AIMConfig::default(),
         Delay,
     )
+    .await
 }

--- a/ossm-esp/src/uart.rs
+++ b/ossm-esp/src/uart.rs
@@ -1,5 +1,6 @@
 use esp_hal::Blocking;
-use esp_hal::uart::Uart;
+use esp_hal::uart::{Config as UartConfig, Uart};
+use ossm::{UartReconfigure, ReadNonBlocking};
 
 /// Newtype wrapper around `Uart<Blocking>` that provides non-blocking
 /// reads via `read_buffered()`. The standard `embedded_io::Read` impl
@@ -7,11 +8,20 @@ use esp_hal::uart::Uart;
 /// modbus transport from implementing timeouts.
 pub struct NonBlockingUart<'d>(pub Uart<'d, Blocking>);
 
+impl UartReconfigure for NonBlockingUart<'_> {
+    type Error = esp_hal::uart::ConfigError;
+
+    async fn reconfigure_baud(&mut self, baud: u32) -> Result<(), Self::Error> {
+        self.0
+            .apply_config(&UartConfig::default().with_baudrate(baud))
+    }
+}
+
 impl embedded_io::ErrorType for NonBlockingUart<'_> {
     type Error = esp_hal::uart::IoError;
 }
 
-impl ossm::ReadNonBlocking for NonBlockingUart<'_> {
+impl ReadNonBlocking for NonBlockingUart<'_> {
     fn read_nb(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
         // read_buffered returns immediately with 0 if the FIFO is empty.
         // RX errors are treated as "no data" to avoid stalling the

--- a/ossm/src/lib.rs
+++ b/ossm/src/lib.rs
@@ -31,7 +31,7 @@ use state::MotionStateChannels;
 pub use state::{MotionPhase, MotionState};
 pub use transport::{
     Modbus, ModbusTransport, ReadNonBlocking, Rs485ModbusTransport, StepDirConfig, StepDirError,
-    StepDirMotor, StepOutput, TransportError,
+    StepDirMotor, StepOutput, TransportError, UartReconfigure,
 };
 
 /// Root container for an OSSM instance.

--- a/ossm/src/transport/mod.rs
+++ b/ossm/src/transport/mod.rs
@@ -3,5 +3,5 @@ pub mod modbus_rtu;
 pub mod step_dir;
 
 pub use modbus::{Modbus, ModbusTransport};
-pub use modbus_rtu::{ReadNonBlocking, Rs485ModbusTransport, TransportError};
+pub use modbus_rtu::{ReadNonBlocking, Rs485ModbusTransport, TransportError, UartReconfigure};
 pub use step_dir::{StepDirConfig, StepDirError, StepDirMotor, StepOutput};

--- a/ossm/src/transport/modbus_rtu.rs
+++ b/ossm/src/transport/modbus_rtu.rs
@@ -23,10 +23,25 @@ pub enum TransportError<E: core::fmt::Debug> {
 }
 
 /// Non-blocking read: returns 0 immediately when no data is available.
-/// Required for timeout support — `embedded_io::Read` on blocking UARTs
+/// Required for timeout support - `embedded_io::Read` on blocking UARTs
 /// hangs forever waiting for data, making timeouts impossible.
 pub trait ReadNonBlocking: ErrorType {
     fn read_nb(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error>;
+}
+
+/// Change the UART's baud rate in place.
+///
+/// Used for one-shot device provisioning - e.g. switching to a motor's
+/// factory baud to issue a baud-change register sequence. MCU-specific
+/// implementations live in the firmware layer; this trait lets the
+/// motor driver request a reconfigure without knowing how to do it.
+#[allow(async_fn_in_trait)]
+pub trait UartReconfigure {
+    type Error: core::fmt::Debug;
+
+    /// Set the UART baud rate. Returns once the hardware is configured
+    /// and ready to send/receive at the new rate.
+    async fn reconfigure_baud(&mut self, baud: u32) -> Result<(), Self::Error>;
 }
 
 /// ModbusTransport over RS485 UART.
@@ -234,5 +249,16 @@ where
             }
         }
         Err(TransportError::Timeout)
+    }
+}
+
+impl<UART, DELAY> UartReconfigure for Rs485ModbusTransport<UART, DELAY>
+where
+    UART: UartReconfigure,
+{
+    type Error = UART::Error;
+
+    async fn reconfigure_baud(&mut self, baud: u32) -> Result<(), Self::Error> {
+        self.uart.reconfigure_baud(baud).await
     }
 }


### PR DESCRIPTION
## Problem

Motors arrive from most manufacturers with a low baudrate. The original firmware by @orange-gem corrected this on boot which is a delightful user experience

## Solution

Implement the same logic here

## Testing

This is currently untested. When I return to my office I'll be able to test this, I have a few stock motors.