### PR TITLE
chore(ossm): use num-traits instead of libm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1189,8 +1189,8 @@ dependencies = [
  "embedded-hal-async",
  "embedded-io 0.6.1",
  "heapless 0.9.2",
- "libm",
  "log",
+ "num-traits",
  "rmodbus",
  "rsruckig",
 ]

--- a/bindings/trajectory-recorder/Cargo.lock
+++ b/bindings/trajectory-recorder/Cargo.lock
@@ -398,8 +398,8 @@ dependencies = [
  "embedded-hal-async",
  "embedded-io",
  "heapless 0.9.2",
- "libm",
  "log",
+ "num-traits",
  "rmodbus",
  "rsruckig",
 ]

--- a/bindings/web-simulator/Cargo.lock
+++ b/bindings/web-simulator/Cargo.lock
@@ -398,8 +398,8 @@ dependencies = [
  "embedded-hal-async",
  "embedded-io",
  "heapless 0.9.2",
- "libm",
  "log",
+ "num-traits",
  "rmodbus",
  "rsruckig",
 ]

--- a/firmware/esp32/Cargo.lock
+++ b/firmware/esp32/Cargo.lock
@@ -1276,6 +1276,7 @@ dependencies = [
  "embedded-io 0.6.1",
  "heapless 0.9.2",
  "log",
+ "num-traits",
  "rmodbus",
  "rsruckig",
 ]

--- a/firmware/esp32s3/Cargo.lock
+++ b/firmware/esp32s3/Cargo.lock
@@ -1323,8 +1323,8 @@ dependencies = [
  "embedded-hal-async",
  "embedded-io 0.6.1",
  "heapless 0.9.2",
- "libm",
  "log",
+ "num-traits",
  "rmodbus",
  "rsruckig",
 ]

--- a/ossm/Cargo.toml
+++ b/ossm/Cargo.toml
@@ -20,4 +20,4 @@ heapless = "0.9.2"
 log = "0.4"
 rmodbus = { version = "0.12.2", default-features = false, features = ["heapless"] }
 crc = { version = "3", default-features = false }
-libm = "0.2.16"
+num-traits = { version = "0.2.19", default-features = false, features = [ "libm" ] }

--- a/ossm/src/motion.rs
+++ b/ossm/src/motion.rs
@@ -1,4 +1,5 @@
 use rsruckig::prelude::*;
+use num_traits::float::Float;
 
 use crate::command::{Cancelled, MotionCommand, StateCommand, StateResponse};
 use crate::state::MotionPhase;
@@ -214,7 +215,7 @@ impl<'a, B: Board> MotionController<'a, B> {
             }
 
             MotionState::Moving => {
-                // Only attempt to update the current motion if 
+                // Only attempt to update the current motion if
                 // A. The remaining time of the existing move is more then 1 second
                 // B. The current max velocity is 0, indicating the device isn't actually moving
                 // C. The current output time is 0, which often indicates an error state.
@@ -377,9 +378,9 @@ impl<'a, B: Board> MotionController<'a, B> {
 
     fn ramp_by_exponent(&self, value: f64, exponent: f64) -> f64 {
         let mut ramped = 1.0 - value;
-        ramped = libm::pow(ramped,exponent);
+        ramped = ramped.powf(exponent);
         ramped = 1.0 - ramped;
-        return libm::pow(ramped,1.0/exponent);
+        return ramped.powf(1.0/exponent);
     }
 
     /// Calculates minimum and maximum jerk values
@@ -389,9 +390,9 @@ impl<'a, B: Board> MotionController<'a, B> {
     /// Only 95% of the maximum value is potentially used. This seems to make ruckig more stable.
     /// When velocity is slowing, previous jerk is used if it is greater then the new jerk to ensure time to slow down.
     fn fraction_to_jerk(&self, fraction: f64, speed: f64) -> f64 {
-        let speed_3 = 2.0 * libm::pow(speed,3.0);
-        let max_jerk = 0.95 * speed_3 / libm::pow(12.0,2.0);
-        let rail_2 = libm::pow(self.limits.max_position_mm - self.limits.min_position_mm,2.0);
+        let speed_3 = 2.0 * speed.powf(3.0);
+        let max_jerk = 0.95 * speed_3 / 12.0.powf(2.0);
+        let rail_2 = (self.limits.max_position_mm - self.limits.min_position_mm).powf(2.0);
         let min_jerk= speed_3 / rail_2;
         let mm_s3 = self.ramp_by_exponent(fraction, 0.5) * max_jerk + min_jerk;
         if self.input.current_velocity[0].abs() > speed && self.input.max_jerk[0] > mm_s3{

--- a/ossm/src/planner/ruckig.rs
+++ b/ossm/src/planner/ruckig.rs
@@ -1,4 +1,5 @@
 use rsruckig::prelude::*;
+use num_traits::float::Float;
 
 use super::{Planner, PlannerOutput};
 
@@ -66,17 +67,17 @@ impl Planner for RuckigPlanner {
         let position = position.clamp(0.0, 1.0);
         let velocity = (velocity_fraction * self.max_velocity).clamp(MIN_VELOCITY, self.max_velocity);
 
-        let speed_3 = 2.0 * libm::pow(velocity,3.0);
-        let max_jerk = speed_3 / libm::pow(0.066,2.0);
+        let speed_3 = 2.0 * velocity.powf(3.0);
+        let max_jerk = speed_3 / 0.066.powf(2.0);
         let rail_2 = 1.0;
         let min_jerk= speed_3 / rail_2;
         jerk_fraction = 1.0 - jerk_fraction;
-        jerk_fraction = libm::pow(jerk_fraction,0.5);
+        jerk_fraction = jerk_fraction.powf(0.5);
         jerk_fraction = 1.0 - jerk_fraction;
-        jerk_fraction = libm::pow(jerk_fraction,2.0);
+        jerk_fraction = jerk_fraction.powf(2.0);
         let mm_s3 = jerk_fraction * max_jerk + min_jerk;
         self.input.max_jerk[0] = mm_s3.clamp(1.0, self.max_jerk);
-        
+
         self.input.target_position[0] = position;
         self.input.max_velocity[0] = velocity;
         self.output.time = 0.0;


### PR DESCRIPTION
## Problem

num-traits provides a generic API for all number formats

## Solution

Use num-traits instead of using libm directly

## Testing

Everything compiles
